### PR TITLE
Raise error if layout.setup() is called with an empty PulseSequence

### DIFF
--- a/silq/meta_instruments/layout.py
+++ b/silq/meta_instruments/layout.py
@@ -589,6 +589,9 @@ class Layout(Instrument):
         Returns:
             None
         """
+        if not self.pulse_sequence:
+            raise RuntimeError("Cannot perform setup with an empty PulseSequence.")
+
         if self.active():
             self.stop()
 


### PR DESCRIPTION
setup() should not succeed without a PulseSequence, this leads to obscure errors when trying to run the null sequence in a loop.

- [x] Raise an error if setup is called without a PulseSequence
- [x] Confirm that nothing relies on setup() with an empty PulseSequence (and if there is, fix it)

@nulinspiratie 