### PR TITLE
Upgraded trace saving

### DIFF
--- a/silq/measurements/measurement_types.py
+++ b/silq/measurements/measurement_types.py
@@ -221,6 +221,7 @@ class Measurement(SettingsClass):
         self.silent = silent
         self.initial_set_vals = None
         self.break_if = break_if
+        self.measurement = None
 
     def __repr__(self):
         return f'{self.name} measurement'
@@ -396,7 +397,7 @@ class Measurement(SettingsClass):
 
         if update:
             logger.info('Updating set parameters to optimal values: '
-                         f'{self.optimal_set_vals}')
+                       f'{self.optimal_set_vals}')
             for set_parameter in self.set_parameters:
                 set_parameter(self.optimal_set_vals[set_parameter.name])
         else:
@@ -404,6 +405,9 @@ class Measurement(SettingsClass):
                          f'{self.initial_set_vals}')
             for set_parameter in self.set_parameters:
                 set_parameter(self.initial_set_vals[set_parameter.name])
+
+    def initialize_measurement(self):
+        raise NotImplementedError('Must be implemented in subclass')
 
     def initialize(self):
         for condition_set in self.condition_sets:
@@ -417,6 +421,16 @@ class Measurement(SettingsClass):
         self.initial_set_vals = {
             p.name: p() for p in self.set_parameters}
         logger.info(f'Initial set values: {self.initial_set_vals}')
+
+        self.measurement = self.initialize_measurement()
+
+        # Create dataset
+        self.dataset = self.measurement.get_data_set(
+            name=self.measurement_name,
+            io=DataSet.default_io,
+            location=self.loc_provider)
+
+        self.acquisition_parameter.base_folder = self.dataset.location
 
     def set_vals_from_idx(self, idx):
         raise NotImplementedError('Must be implemented in subclass')
@@ -440,9 +454,13 @@ class Loop0DMeasurement(Measurement):
         """
         return {}
 
+    def initialize_measurement(self):
+        self.measurement = qc.Measure(self.acquisition_parameter)
+        return self.measurement
+
     @property
-    def measurement(self):
-        return qc.Measure(self.acquisition_parameter)
+    def measurement_name(self):
+        return f'{self.name}_{self.acquisition_parameter.name}'
 
     @clear_single_settings
     def get(self, set_active=True):
@@ -453,12 +471,12 @@ class Loop0DMeasurement(Measurement):
         """
         self.initialize()
 
-        measurement_name = f'{self.name}_{self.acquisition_parameter.name}'
-        logger.info(f'Performing 0D measurement {measurement_name}')
-        self.dataset = self.measurement.run(name=measurement_name,
-                                            io=DataSet.default_io,
-                                            location=self.loc_provider,
-                                            quiet=True, set_active=set_active)
+        logger.info(f'Performing 0D measurement {self.measurement_name}')
+        try:
+            self.measurement.run(quiet=True, set_active=set_active)
+        finally:
+            self.acquisition_parameter.base_folder = None
+
 
         # Test condition sets until a condition_set is found that has an action
         condition_set = self.check_condition_sets(self.dataset,
@@ -514,8 +532,7 @@ class Loop1DMeasurement(Measurement):
                                                 set_parameter.name)[idx]
                     for set_parameter in self.set_parameters}
 
-    @property
-    def measurement(self):
+    def initialize_measurement(self):
         # Start with an empty set of actions in the loop
         actions = []
 
@@ -527,6 +544,8 @@ class Loop1DMeasurement(Measurement):
 
             # Also measure the set_parameters, as we are going to update them
             actions += self.set_parameters
+        else:
+            raise RuntimeError('Either set_vals or point must be defined')
 
         # Add measurement of acquisition parameter
         actions.append(self.acquisition_parameter)
@@ -536,7 +555,13 @@ class Loop1DMeasurement(Measurement):
                                            self.acquisition_parameter,
                                            action=self.break_if)))
 
-        return set_loop.each(*actions)
+        self.measurement = set_loop.each(*actions)
+        return self.measurement
+
+    @property
+    def measurement_name(self):
+        return f'{self.name}_{self.set_parameter.name}_' \
+               f'{self.acquisition_parameter.name}'
 
     @clear_single_settings
     def get(self, set_active=True):
@@ -547,13 +572,11 @@ class Loop1DMeasurement(Measurement):
         """
         self.initialize()
 
-        measurement_name = f'{self.name}_{self.set_parameter.name}_' \
-                           f'{self.acquisition_parameter.name}'
-        logger.info(f'Performing 1D measurement {measurement_name}')
-        self.dataset = self.measurement.run(name=measurement_name,
-                                            io=DataSet.default_io,
-                                            location=self.loc_provider,
-                                            quiet=True, set_active=set_active)
+        logger.info(f'Performing 1D measurement {self.measurement_name}')
+        try:
+            self.measurement.run(quiet=True, set_active=set_active)
+        finally:
+            self.acquisition_parameter.base_folder = None
 
         # Test condition sets until a condition_set is found that has an action
         condition_set = self.check_condition_sets(self.dataset,
@@ -607,10 +630,9 @@ class Loop2DMeasurement(Measurement):
             return {self.set_parameters[0].name: self.set_vals[0][idxs[0]],
                     self.set_parameters[1].name: self.set_vals[1][idxs[1]]}
 
-    @property
-    def measurement(self):
+    def initialize_measurement(self):
         if self.break_if is False:
-            return qc.Loop(
+            self.measurement = qc.Loop(
                 self.set_vals[0]).loop(
                     self.set_vals[1]).each(
                         self.acquisition_parameter)
@@ -618,13 +640,20 @@ class Loop2DMeasurement(Measurement):
             break_action = BreakIf(partial(self.satisfies_condition_set,
                                            self.acquisition_parameter,
                                            action=self.break_if))
-            return qc.Loop(
+            self.measurement = qc.Loop(
                 self.set_vals[0]).each(
                     qc.Loop(
                         self.set_vals[1]).each(
                         self.acquisition_parameter,
                         break_action),
                     break_action)
+        return self.measurement
+
+    @property
+    def measurement_name(self):
+        return f'{self.name}_{self.set_parameters[0].name}_' \
+               f'{self.set_parameters[1].name}_' \
+               f'{self.acquisition_parameter.name}'
 
     @clear_single_settings
     def get(self, set_active=True):
@@ -635,17 +664,15 @@ class Loop2DMeasurement(Measurement):
         """
         self.initialize()
 
-        measurement_name = f'{self.name}_{self.set_parameters[0].name}_' \
-                           f'{self.set_parameters[1].name}_' \
-                           f'{self.acquisition_parameter.name}'
-        logger.info(f'Performing 2D measurement {measurement_name} ')
+        logger.info(f'Performing 2D measurement {self.measurement_name} ')
         logger.info(
             f'set_vals: {self.set_parameters[0].name}[{self.set_vals[0][:]}], '
             f'{self.set_parameters[1].name}[{self.set_vals[1][:]}')
-        self.dataset = self.measurement.run(name=measurement_name,
-                                            io=DataSet.default_io,
-                                            location=self.loc_provider,
-                                            quiet=True, set_active=set_active)
+
+        try:
+            self.measurement.run(quiet=True, set_active=set_active)
+        finally:
+            self.acquisition_parameter.base_folder = None
 
         # Test condition sets until a condition_set is found that has an action
         condition_set = self.check_condition_sets(self.dataset,

--- a/silq/parameters/acquisition_parameters.py
+++ b/silq/parameters/acquisition_parameters.py
@@ -6,10 +6,8 @@ from blinker import signal
 from functools import partial
 import logging
 
-from qcodes.instrument.parameter import MultiParameter
-from qcodes.data import hdf5_format, io
-from qcodes.data.data_array import DataArray
-from qcodes.loops import active_loop
+from qcodes import DataSet, DataArray, MultiParameter, active_data_set
+from qcodes.data import hdf5_format
 
 from silq import config
 from silq.pulses import *
@@ -81,6 +79,7 @@ class AcquisitionParameter(SettingsClass, MultiParameter):
         self.dataset = None
         self.results = None
 
+        self.base_folder = None
         self.subfolder = None
 
         self.continuous = continuous
@@ -123,22 +122,29 @@ class AcquisitionParameter(SettingsClass, MultiParameter):
             setattr(self, key, val)
 
     def store_traces(self, pulse_traces, base_folder=None, subfolder=None,
-                     channels=['output']):
+                     channels=['output'], setpoints=False):
+
         # Store raw traces
         if base_folder is None:
             # Extract base_folder from dataset of currently active loop
-            active_dataset = active_loop().get_data_set()
-            if active_dataset.location:
+            active_dataset = active_data_set()
+            if self.base_folder is not None:
+                base_folder = self.base_folder
+            elif getattr(active_dataset, 'location', None):
                 base_folder = active_dataset.location
             elif hasattr(active_dataset, '_location'):
                 base_folder = active_dataset._location
+
+            if subfolder is None and base_folder is not None:
+                subfolder = f'traces_{self.name}'
+            else:
+                base_folder = DataSet.location_provider(DataSet.default_io)
+
         self.dataset = data_tools.create_data_set(name='traces',
                                                   base_folder=base_folder,
                                                   subfolder=subfolder,
                                                   formatter=self.formatter)
 
-        # Create dictionary of set arrays
-        set_arrs = {}
         traces_dict = {}
         for pulse_name, channel_traces in pulse_traces.items():
             for channel in channels:
@@ -146,42 +152,49 @@ class AcquisitionParameter(SettingsClass, MultiParameter):
                 traces = channel_traces[channel]
                 traces_dict[traces_name] = traces
 
+        if setpoints:
+            # Create dictionary of set arrays
+            set_arrs = {}
+            for traces_name, traces in traces_dict.items():
                 number_of_traces, points_per_trace = traces.shape
 
                 if traces.shape not in set_arrs:
                     time_step = 1 / self.sample_rate * 1e3
-                    t_list = np.arange(0, points_per_trace * time_step, time_step)
-                    t_list_arr = DataArray(name='time',
-                                           array_id='time',
-                                           label=' Time',
-                                           unit='ms',
-                                           shape=traces.shape,
-                                           preset_data=np.full(traces.shape,
-                                                               t_list),
-                                           is_setpoint=True)
+                    t_list = np.arange(0, points_per_trace * time_step,
+                                       time_step)
+                    t_list_arr = DataArray(
+                        name='time',
+                        array_id='time',
+                        label=' Time',
+                        unit='ms',
+                        shape=traces.shape,
+                        preset_data=np.full(traces.shape, t_list),
+                        is_setpoint=True)
 
-                    trace_num_arr = DataArray(name='trace_num',
-                                              array_id='trace_num',
-                                              label='Trace',
-                                              unit='num',
-                                              shape=(number_of_traces, ),
-                                              preset_data=np.arange(
-                                                  number_of_traces, dtype=np.float64),
-                                              is_setpoint=True)
+                    trace_num_arr = DataArray(
+                        name='trace_num',
+                        array_id='trace_num',
+                        label='Trace',
+                        unit='num',
+                        shape=(number_of_traces, ),
+                        preset_data=np.arange(number_of_traces,
+                                              dtype=np.float64),
+                        is_setpoint=True)
                     set_arrs[traces.shape] = (trace_num_arr, t_list_arr)
 
-        # Add set arrays to dataset
-        for k, (t_list_arr, trace_num_arr) in enumerate(set_arrs.values()):
-            for arr in (t_list_arr, trace_num_arr):
-                if len(set_arrs) > 1:
-                    # Need to give individual array_ids to each of the set arrays
-                    arr.array_id += '_{}'.format(k)
-                self.dataset.add_array(arr)
+            # Add set arrays to dataset
+            for k, (t_list_arr, trace_num_arr) in enumerate(set_arrs.values()):
+                for arr in (t_list_arr, trace_num_arr):
+                    if len(set_arrs) > 1:
+                        # Need to give individual array_ids to each of the set arrays
+                        arr.array_id += '_{}'.format(k)
+                    self.dataset.add_array(arr)
+            set_arrays = (t_list_arr, trace_num_arr)
+        else:
+            set_arrays = ()
 
         # Add trace arrs to dataset
         for traces_name, traces in traces_dict.items():
-            t_list_arr, trace_num_arr = set_arrs[traces.shape]
-
             # Must transpose traces array
             trace_arr = DataArray(name=traces_name,
                                   array_id=traces_name,
@@ -189,7 +202,7 @@ class AcquisitionParameter(SettingsClass, MultiParameter):
                                   unit='V',
                                   shape=traces.shape,
                                   preset_data=traces,
-                                  set_arrays=(t_list_arr, trace_num_arr))
+                                  set_arrays=set_arrays)
             self.dataset.add_array(trace_arr)
 
         self.dataset.finalize()
@@ -1024,6 +1037,14 @@ class NeuralRetuneParameter(NeuralNetworkParameter):
         elif isinstance(self.include_target_output, Iterable):
             names = names + self.include_target_output
         return names
+
+    @property
+    def base_folder(self):
+        return self.target_parameter.base_folder
+
+    @base_folder.setter
+    def base_folder(self, base_folder):
+        self.target_parameter.base_folder = base_folder
 
     def get(self):
         self.acquire()

--- a/silq/tools/data_tools.py
+++ b/silq/tools/data_tools.py
@@ -1,25 +1,21 @@
 import os
 import numpy as np
 from dateutil.parser import parse
-from collections import Iterable
 import logging
-
-
-logger = logging.getLogger(__name__)
-
 
 import qcodes as qc
 from silq import config
-from qcodes.instrument.parameter import Parameter, ManualParameter
-from qcodes.data.data_set import new_data, DataSet
-from qcodes.data.data_array import DataArray
+from qcodes.data.data_set import new_data
+
+
+logger = logging.getLogger(__name__)
 
 
 def create_data_set(name, base_folder, subfolder=None, formatter=None):
     location_string = '{base_folder}/'
     if subfolder is not None:
         location_string += '{subfolder}/'
-    location_string += '#{{counter}}_{name}'
+    location_string += '#{{counter}}_{{name}}_{{time}}'
 
     location = qc.data.location.FormatLocation(
         fmt=location_string.format(base_folder=base_folder, name=name,


### PR DESCRIPTION
This PR improves functionality of trace saving.

- Remove setpoints from traces saving, as this doubled the amount of data. The downside is that the setpoints are gone, so a custom x/y axis will need to be defined.
- Timestamp added to trace folder names
- Trace datasets have a better folder structure. Grouped together per acquisition parameter.
- For any submeasurement (e.g. retuning), the traces are saved in the respective folder