### PR TITLE
Feature/Adiabatic and NMR acquisition parameters upgrade

### DIFF
--- a/silq/parameters/acquisition_parameters.py
+++ b/silq/parameters/acquisition_parameters.py
@@ -967,9 +967,11 @@ class NMRParameter(AcquisitionParameter):
         self.NMR_pulse = SinePulse('NMR')
         self.NMR_stage_pulse = DCPulse('empty')
         self.ESR_pulse = FrequencyRampPulse('adiabatic_ESR')
+        self.read_pulse = DCPulse('read_initialize', acquire=True)
         self.ESR_pulses = [self.ESR_pulse]
         self.post_pulses = []
 
+        self.t_read = None
         self.pulse_delay = 5
         self.inter_pulse_delay = 1
 
@@ -1036,7 +1038,7 @@ class NMRParameter(AcquisitionParameter):
                     delay = self.pulse_delay + k * self.inter_pulse_delay
                     ESR_pulse.t_start = PulseMatch(plunge_pulse, 't_start',
                                                    delay=delay)
-                self.pulse_sequence.add(DCPulse('read', acquire=True))
+                self.pulse_sequence.add(self.read_pulse)
 
         self.pulse_sequence.add(*self.post_pulses)
 
@@ -1088,7 +1090,8 @@ class NMRParameter(AcquisitionParameter):
             threshold_up_proportion=self.threshold_up_proportion,
             shots_per_read=self.shots_per_frequency,
             sample_rate=self.sample_rate,
-            t_skip=self.t_skip)
+            t_skip=self.t_skip,
+            t_read=self.t_read)
 
         # Store raw traces if self.save_traces is True
         if self.save_traces:


### PR DESCRIPTION
This PR provides some upgrades for the adiabatic parameter and the NMR parameter.
- Adiabatic_ESR_parameter has been renamed to ESR_parameter, and now can be used for both adiabatic ESR pulses, as well as single-frequency ESR pulses (Rabi).
- Rabi Parameter has been removed
- NMR parameter now has shots in the outer loop, and in each inner loop goes over the ESR frequencies.
- NMR analysis has been updated accordingly