### PR TITLE
Fix/config deepcopy

### DIFF
--- a/silq/tools/config.py
+++ b/silq/tools/config.py
@@ -3,6 +3,7 @@ import collections
 from blinker import signal
 import json
 from functools import partial
+import copy
 
 import qcodes as qc
 from qcodes.config.config import DotDict
@@ -239,6 +240,20 @@ class DictConfig(SubConfig, DotDict):
         config = super().load(folder=folder)
         update(self, config)
 
+    def to_dict(self):
+        d = {}
+        for key, val in self.items():
+            if isinstance(val, DictConfig):
+                d[key] = val.to_dict()
+            elif isinstance(val, ListConfig):
+                d[key] = val.to_list()
+            else:
+                d[key] = val
+        return d
+
+    def __deepcopy__(self, memo):
+        return copy.deepcopy(self.to_dict())
+
 
 class ListConfig(SubConfig, list):
     def __init__(self, name, folder=None, parent=None, config=None, **kwargs):
@@ -255,6 +270,19 @@ class ListConfig(SubConfig, list):
         config = super().load(folder=folder)
         self += config
 
+    def to_list(self):
+        l = []
+        for val in self:
+            if isinstance(val, DictConfig):
+                l.append(val.to_dict())
+            elif isinstance(val, ListConfig):
+                l.append(val.to_list())
+            else:
+                l.append(val)
+        return l
+
+    def __deepcopy__(self, memo):
+        return copy.deepcopy(self.to_list())
 
 def update(d, u):
     """ 


### PR DESCRIPTION
Deepcopy of a SubConfig gave a RecursionError. Somehow, it also tries to copy its parent SubConfig, which then again copies the child SubConfig etc.

As a fix, we first convert the configs to dicts/lists. This will mean that a copy of a silq Config will lose all its additional features, but copying a SubConfig probably isn't really needed anyway