### PR TITLE
feat: add more informative error message for pulses without duration

### DIFF
--- a/silq/pulses/pulse_modules.py
+++ b/silq/pulses/pulse_modules.py
@@ -451,6 +451,12 @@ class PulseSequence(ParameterNode):
             original pulse remains unmodified.
             For an speed-optimized version, see `PulseSequence.quick_add`
         """
+        pulses_no_duration = [pulse for pulse in pulses if pulse.duration is None]
+        if pulses_no_duration:
+            raise SyntaxError('Please specify pulse duration in silq.config.pulses'
+                              ' for the following pulses: ' +
+                              ', '.join(p.name for p in pulses_no_duration))
+
         added_pulses = []
 
         for pulse in pulses:
@@ -551,6 +557,12 @@ class PulseSequence(ParameterNode):
             `PulseSequence.quick_add`.
 
         """
+        pulses_no_duration = [pulse for pulse in pulses if pulse.duration is None]
+        if pulses_no_duration:
+            raise SyntaxError('Please specify pulse duration in silq.config.pulses'
+                              ' for the following pulses: ' +
+                              ', '.join(p.name for p in pulses_no_duration))
+
         added_pulses = []
         for pulse in pulses:
             assert pulse.implementation is not None or self.allow_untargeted_pulses, \


### PR DESCRIPTION
When a pulse without duration is added to the pulse sequence, an error is raised.
Currently the error only shows the first pulse that does not have a duration.
However, if multiple pulses are added simultaneously, it is unclear if the subsequent ones also need a duration to be specified.

Here a more informative error message is added, where all the pulses without durations are specified.

This is especially relevant for a new experimental setup where AcquisitionParameters are initialized.