### PR TITLE
Hotfix/analysis threshold voltage bug

### DIFF
--- a/silq/analysis/analysis.py
+++ b/silq/analysis/analysis.py
@@ -189,7 +189,7 @@ def find_high_low(traces: np.ndarray,
 
     SNR = voltage_difference / np.sqrt(high['std'] ** 2 + low['std'] ** 2)
     if min_SNR is None:
-        min_SNR = analysis_config.min_SNR
+        min_SNR = analysis_config.get('min_SNR')
     if min_SNR is not None and SNR < min_SNR:
         logger.info(f'Signal to noise ratio {SNR} is too low')
         threshold_voltage = None


### PR DESCRIPTION
The mean threshold voltage for current blips was not calculated correctly.
This PR fixes the bug.

Additionally, an error was raised when `min_SNR` was not passed as a kwarg and also undefined in the analysis config