### PR TITLE
fix: copy explicitly set duration of a pulse sequence

### DIFF
--- a/silq/pulses/pulse_modules.py
+++ b/silq/pulses/pulse_modules.py
@@ -391,6 +391,10 @@ class PulseSequence(ParameterNode):
 
         # Add pulses (which will create copies)
         self_copy.pulses = self.pulses
+
+        # If duration is fixed (i.e. pulse_sequence.duration=val), ensure this
+        # is also copied
+        self_copy['duration']._duration = self['duration']._duration
         return self_copy
 
     def _ipython_key_completions_(self):


### PR DESCRIPTION
Found the following bug:
When a pulse sequence has its duration explicitly set, this explicit set is not copied.
Therefore, the Layout never takes this into account.

Should be good to go