### PR TITLE
feat: More succinct layout log message

### DIFF
--- a/silq/meta_instruments/layout.py
+++ b/silq/meta_instruments/layout.py
@@ -1460,7 +1460,7 @@ class Layout(Instrument):
             `Layout.save_traces`
         """
         try:
-            logger.info(f'Performing acquisition, {["continue", "stop"][stop]} when finished')
+            logger.info(f'Performing acquisition, {"stop" if stop else "continue"]} when finished')
             if not self.active():
                 self.start()
 


### PR DESCRIPTION
Some log messages of the layout are unnecessarily long. Here we shorten them