### PR TITLE
Ignore single_settings if it is None

### DIFF
--- a/silq/tools/general_tools.py
+++ b/silq/tools/general_tools.py
@@ -185,7 +185,9 @@ class SettingsClass:
 
         self._single_settings.clear()
         for item, value in kwargs.items():
-            if hasattr(self, item):
+            if value is None:
+                continue
+            elif hasattr(self, item):
                 self._single_settings[item] = value
             else:
                 raise ValueError('Setting {} not found'.format(item))


### PR DESCRIPTION
In this PR, we change the behaviuor of single_settings such that it ignores None.
For example, the kwarg `samples` is ignored in the following situation:
`NMR_parameter(samples=None)`

It's a fairly irrelevant issue, but I have come across situations where it is useful to ignore such kwargs. The main situation is this:

```
# define settings at the top of a cell
samples = None  # We don't want to modify samples this time
...

# Actual code
NMR_parameter(samples=samples)
```
In this situation, we want to be able to set samples to whatever we want, but also want to be able to use the default value.