### PR TITLE
added new EDSR parameter based on NMR parameter

### DIFF
--- a/silq/parameters/acquisition_parameters.py
+++ b/silq/parameters/acquisition_parameters.py
@@ -1959,8 +1959,7 @@ class EDSRParameter(NMRParameter):
 
     def __init__(self, name: str = 'EDSR',
                  names: List[str] = ['flips', 'flip_probability', 'up_proportions',
-                                     'state_probability_0', 'state_probability_1',
-                                     'EDSR_up_proportion'],
+                                     'success_probability', 'EDSR_up_proportion'],
                  **kwargs):
         super().__init__(name=name,
                          names=names,

--- a/silq/parameters/acquisition_parameters.py
+++ b/silq/parameters/acquisition_parameters.py
@@ -2009,21 +2009,13 @@ class EDSRParameter(NMRParameter):
         """
         results = super().analyse(traces)
 
-        # Extract points for read DC pulse after EDSR pulse
-        EDSR_read_traces_name = f"{self.NMR['post_pulse'].name}"
-        EDSR_read_traces = traces[EDSR_read_traces_name]['output']
-        EDSR_trace_points = EDSR_read_traces.shape[1]
-
-        self.EDSR_traces = np.zeros((self.samples, EDSR_trace_points))
-        self.EDSR_traces = EDSR_read_traces
         EDSR_read_result = analysis.analyse_traces(
-            traces=EDSR_read_traces,
+            traces=traces[self.NMR['post_pulse'].name]['output'],
             sample_rate=self.sample_rate,
             t_read=self.t_read,
             t_skip=self.t_skip,
             threshold_voltage=self.threshold_up_proportion)
-        EDSR_up_proportion = EDSR_read_result['up_proportion']
-        results['EDSR_up_proportion'] = EDSR_up_proportion
+        results['EDSR_up_proportion'] = EDSR_read_result['up_proportion']
 
         return results
 

--- a/silq/parameters/acquisition_parameters.py
+++ b/silq/parameters/acquisition_parameters.py
@@ -23,7 +23,7 @@ from silq.tools.general_tools import SettingsClass, clear_single_settings, \
 
 __all__ = ['AcquisitionParameter', 'DCParameter', 'TraceParameter',
            'DCSweepParameter', 'EPRParameter', 'ESRParameter',
-           'NMRParameter', 'VariableReadParameter', 'BlipsParameter',
+           'NMRParameter', 'EDSRParameter', 'VariableReadParameter', 'BlipsParameter',
            'FlipNucleusParameter', 'FlipFlopParameter', 'NeuralNetworkParameter',
            'NeuralRetuneParameter','ESRRamseyDetuningParameter']
 
@@ -1970,7 +1970,7 @@ class EDSRParameter(NMRParameter):
     Parameter for EDSR measurements based on NMR parameter and pulse sequence
 
     Refer to NMRParameter for details. In addition to all properties copied from NMRParameter,
-    EDSRParameter has additional analysis of electron readout right after EDSR(NMR) pulse during
+    EDSRParameter includes analysis of electron readout right after EDSR(NMR) pulse during
     NMR['post_pulse'] = DCPulse('read') that needs to be present in NMRPulseSequence.
 
     Args:
@@ -1981,7 +1981,8 @@ class EDSRParameter(NMRParameter):
 
     def __init__(self, name: str = 'EDSR',
                  names: List[str] = ['flips', 'flip_probability', 'up_proportions',
-                                     'state_probability', 'EDSR_up_proportion'],
+                                     'state_probability', 'threshold_up_proportion',
+                                     'EDSR_up_proportion'],
                  **kwargs):
         super().__init__(name=name,
                          names=names,

--- a/silq/parameters/acquisition_parameters.py
+++ b/silq/parameters/acquisition_parameters.py
@@ -1968,7 +1968,7 @@ class EDSRParameter(NMRParameter):
 
     def __init__(self, name: str = 'EDSR',
                  names: List[str] = ['flips', 'flip_probability', 'up_proportions',
-                                     'success_probability', 'EDSR_up_proportion'],
+                                     'state_probability', 'EDSR_up_proportion'],
                  **kwargs):
         super().__init__(name=name,
                          names=names,


### PR DESCRIPTION
In the new NMR pulse sequence, there is an additional "read" post-pulse after NMR pulse that can be used for electron-readout in EDSR measurements. This parameter was not tested yet and requires update to the new pulse sequence first to work