### PR TITLE
Add a check if phase_reference is an attr of the class.

### DIFF
--- a/silq/pulses/pulse_types.py
+++ b/silq/pulses/pulse_types.py
@@ -813,8 +813,8 @@ class FrequencyRampPulse(Pulse):
                 # This formula assumes the source is 50 Ohm matched and power is in dBm
                 # A factor of 2 comes from the conversion from amplitude to RMS.
                 amplitude = np.sqrt(10 ** (self.power / 10) * 1e-3 * 100)
-
-        if self.phase_reference == 'relative':
+        # Check if phase_reference is defined for backwards-compatibility
+        if not hasattr(self, 'phase_reference') or self.phase_reference == 'relative':
             t = t - self.t_start
 
         return amplitude * np.sin(2 * np.pi * (frequency_start * t + frequency_rate * np.power(t,2) / 2))


### PR DESCRIPTION
This enables backwards-compatibility with old pulse sequences.