### PR TITLE
Make the path OS independent for get_pulse_sequence.

### DIFF
--- a/silq/__init__.py
+++ b/silq/__init__.py
@@ -425,7 +425,8 @@ def _get_pulse_sequence(self, idx=0, pulse_name=None, silent=False):
         while current_date <= date_time + timedelta(days=max_date_delta):
             date_str = date_time.strftime("%Y-%m-%d")
             pulse_sequence_path = os.path.join(
-                self.default_io.base_location, r'pulse_sequences\data', date_str
+                self.default_io.base_location, r'pulse_sequences', 'data',
+                date_str
             )
             pulse_sequence_files = os.listdir(pulse_sequence_path)
             # Sort by their idx (i.e. #095 at start of filename)


### PR DESCRIPTION
Small fix for unix-like paths.
I'm still unsure about [one line ](https://github.com/nulinspiratie/SilQ/blob/f70ec5687c08266e47a354f45b311117a86c6716/silq/__init__.py#L463), I can't figure out why pulse sequences have a '\\\\' in them by default. I can't find where this gets added, but it doesn't seem to be an issue for now so long as pulse sequences aren't created on a unix-like system, I suppose.