### PR TITLE
fixed IQ modulation mode for single frequency pulses

### DIFF
--- a/silq/instrument_interfaces/keysight/E8267D_interface.py
+++ b/silq/instrument_interfaces/keysight/E8267D_interface.py
@@ -55,6 +55,9 @@ class E8267DInterface(InstrumentInterface):
             SinePulseImplementation(
                 pulse_requirements=[('frequency', {'min': 250e3, 'max': 44e9})]
             ),
+            MultiSinePulseImplementation(
+                pulse_requirements=[('frequency', {'min': 250e3, 'max': 44e9})]
+            ),
             FrequencyRampPulseImplementation(
                 pulse_requirements=[
                     ('frequency_start', {'min': 250e3, 'max': 44e9}),
@@ -469,7 +472,7 @@ class MultiSinePulseImplementation(PulseImplementation):
             raise ValueError('FM_mode should be IQ and '
                              'IQ_modulation should be ON for MultiSinePulses')
         else:
-            frequencies_IQ = np.array(self.pulse.frequencies) - interface.frequency()
+            frequencies_IQ = list(np.array(self.pulse.frequencies) - interface.frequency())
 
         additional_pulses.extend([
             MultiSinePulse(name='sideband_I',
@@ -484,7 +487,7 @@ class MultiSinePulseImplementation(PulseImplementation):
             MultiSinePulse(name='sideband_Q',
                            t_start=self.pulse.t_start - interface.envelope_padding(),
                            t_stop=self.pulse.t_stop + interface.envelope_padding(),
-                           frequency=frequencies_IQ,
+                           frequencies=frequencies_IQ,
                            phase=self.pulse.phase-90,
                            amplitude=1,
                            connection_requirements={

--- a/silq/instrument_interfaces/keysight/E8267D_interface.py
+++ b/silq/instrument_interfaces/keysight/E8267D_interface.py
@@ -3,7 +3,7 @@ from time import sleep
 
 from silq.instrument_interfaces import InstrumentInterface, Channel
 from silq.pulses import Pulse, DCPulse, DCRampPulse, SinePulse, \
-    FrequencyRampPulse, MarkerPulse, PulseImplementation
+    MultiSinePulse, FrequencyRampPulse, MarkerPulse, PulseImplementation
 
 from qcodes.utils import validators as vals
 
@@ -446,4 +446,48 @@ class FrequencyRampPulseImplementation(PulseImplementation):
                             connection_requirements={
                                 'input_instrument': interface.instrument_name(),
                                 'input_channel': interface.modulation_channel()})))
+        return additional_pulses
+
+
+class MultiSinePulseImplementation(PulseImplementation):
+    pulse_class = MultiSinePulse
+
+    def target_pulse(self, pulse, interface, **kwargs):
+        assert pulse.power is not None, "Pulse must have power defined"
+        return super().target_pulse(pulse, interface, **kwargs)
+
+    def get_additional_pulses(self, interface: InstrumentInterface):
+        # Add an envelope pulse
+        additional_pulses = [
+            MarkerPulse(t_start=self.pulse.t_start, t_stop=self.pulse.t_stop,
+                        amplitude=interface.marker_amplitude(),
+                        connection_requirements={
+                            'input_instrument': interface.instrument_name(),
+                            'input_channel': 'trig_in'})]
+
+        if (interface.IQ_modulation() == 'off') or (interface.FM_mode() == 'ramp'):
+            raise ValueError('FM_mode should be IQ and '
+                             'IQ_modulation should be ON for MultiSinePulses')
+        else:
+            frequencies_IQ = np.array(self.pulse.frequencies) - interface.frequency()
+
+        additional_pulses.extend([
+            MultiSinePulse(name='sideband_I',
+                           t_start=self.pulse.t_start - interface.envelope_padding(),
+                           t_stop=self.pulse.t_stop + interface.envelope_padding(),
+                           frequencies=frequencies_IQ,
+                           amplitude=1,
+                           phase=self.pulse.phase,
+                           connection_requirements={
+                               'input_instrument': interface.instrument_name(),
+                               'input_channel': 'I'}),
+            MultiSinePulse(name='sideband_Q',
+                           t_start=self.pulse.t_start - interface.envelope_padding(),
+                           t_stop=self.pulse.t_stop + interface.envelope_padding(),
+                           frequency=frequencies_IQ,
+                           phase=self.pulse.phase-90,
+                           amplitude=1,
+                           connection_requirements={
+                               'input_instrument': interface.instrument_name(),
+                               'input_channel': 'Q'})])
         return additional_pulses

--- a/silq/instrument_interfaces/keysight/E8267D_interface.py
+++ b/silq/instrument_interfaces/keysight/E8267D_interface.py
@@ -55,9 +55,6 @@ class E8267DInterface(InstrumentInterface):
             SinePulseImplementation(
                 pulse_requirements=[('frequency', {'min': 250e3, 'max': 44e9})]
             ),
-            MultiSinePulseImplementation(
-                pulse_requirements=[('frequency', {'min': 250e3, 'max': 44e9})]
-            ),
             FrequencyRampPulseImplementation(
                 pulse_requirements=[
                     ('frequency_start', {'min': 250e3, 'max': 44e9}),
@@ -472,7 +469,7 @@ class MultiSinePulseImplementation(PulseImplementation):
             raise ValueError('FM_mode should be IQ and '
                              'IQ_modulation should be ON for MultiSinePulses')
         else:
-            frequencies_IQ = list(np.array(self.pulse.frequencies) - interface.frequency())
+            frequencies_IQ = np.array(self.pulse.frequencies) - interface.frequency()
 
         additional_pulses.extend([
             MultiSinePulse(name='sideband_I',
@@ -487,7 +484,7 @@ class MultiSinePulseImplementation(PulseImplementation):
             MultiSinePulse(name='sideband_Q',
                            t_start=self.pulse.t_start - interface.envelope_padding(),
                            t_stop=self.pulse.t_stop + interface.envelope_padding(),
-                           frequencies=frequencies_IQ,
+                           frequency=frequencies_IQ,
                            phase=self.pulse.phase-90,
                            amplitude=1,
                            connection_requirements={

--- a/silq/instrument_interfaces/keysight/E8267D_interface.py
+++ b/silq/instrument_interfaces/keysight/E8267D_interface.py
@@ -162,11 +162,6 @@ class E8267DInterface(InstrumentInterface):
         if None in frequency_sidebands:
             frequency_sidebands.remove(None)
 
-        if frequency_sidebands or self.FM_mode() == 'IQ':
-            self.IQ_modulation._save_val('on')
-        else:
-            self.IQ_modulation._save_val('off')
-
         # Find minimum and maximum frequency
         min_frequency = max_frequency = None
         for pulse in self.pulse_sequence:
@@ -211,6 +206,11 @@ class E8267DInterface(InstrumentInterface):
             "Maximum FM frequency deviation is 80 MHz if FM_mode == 'ramp'. " \
             f"Current frequency deviation: {self.frequency_deviation()/1e6} MHz"
 
+        if frequency_sidebands or (self.FM_mode() == 'IQ' and min_frequency != max_frequency):
+            self.IQ_modulation._save_val('on')
+        else:
+            self.IQ_modulation._save_val('off')
+
         additional_pulses = []
         for pulse in self.pulse_sequence:
             additional_pulses += pulse.implementation.get_additional_pulses(interface=self)
@@ -243,7 +243,7 @@ class E8267DInterface(InstrumentInterface):
         self.instrument.pulse_modulation_source('ext')
         self.instrument.output_modulation('on')
 
-        if self.IQ_modulation() == 'on' or self.FM_mode() == 'IQ':
+        if self.IQ_modulation() == 'on':
             self.instrument.internal_IQ_modulation('on')
         else:
             self.instrument.internal_IQ_modulation('off')


### PR DESCRIPTION
In IQ modulation mode if you pulse only with single frequency, i.e. you don't need IQ modulation, it shows an error. It is fixed now - was copied by Serwan from Queenie.