### PR TITLE
Clean interface snapshot

### DIFF
--- a/silq/instrument_interfaces/interface.py
+++ b/silq/instrument_interfaces/interface.py
@@ -1,4 +1,4 @@
-from typing import Union, List, Dict, Any, Tuple
+from typing import Union, List, Dict, Any, Tuple, Sequence
 import logging
 
 from qcodes import Instrument
@@ -126,6 +126,26 @@ class InstrumentInterface(Instrument):
 
     def __repr__(self):
         return f'{self.name} interface'
+
+    def snapshot_base(
+            self,
+            update: bool=False,
+            params_to_skip_update: Sequence[str]=None
+    ):
+        snapshot = super().snapshot_base(
+            update=update,
+            params_to_skip_update=params_to_skip_update,
+            skip_parameter_nodes=[
+                'instrument',
+                'pulse_sequence',
+                'input_pulse_sequence',
+                'targeted_pulse_sequence',
+                'targeted_input_pulse_sequence',
+                'additional_settings'
+            ]
+        )
+        snapshot['parameter_nodes']['instrument'] = self.instrument.name
+        return snapshot
 
     def get_channel(self, channel_name: str) -> Channel:
         """Get channel by its name.


### PR DESCRIPTION
Removes the following items from interface snapshots:
- instrument (instruments should be added to the station separately)
- pulse_sequence
- input_pulse_sequence
- targeted_pulse_sequence
- targeted_input_pulse_sequence

Requires https://github.com/nulinspiratie/Qcodes/pull/74