### PR TITLE
Fix: do not determine fit parameters if already performed

### DIFF
--- a/silq/analysis/fit_toolbox.py
+++ b/silq/analysis/fit_toolbox.py
@@ -157,7 +157,7 @@ class Fit():
         """
 
         if parameters is None:
-            if kwargs:
+            if kwargs and self.parameters is None:
                 self.get_parameters(**kwargs)
             parameters = self.parameters
 


### PR DESCRIPTION
This causes issues where initial parameters are sometimes calculated twice. It can also raise an error