### PR TITLE
Fix: Check if using ipython before registering magic

### DIFF
--- a/silq/__init__.py
+++ b/silq/__init__.py
@@ -33,7 +33,7 @@ qc.config.user.update({'silq_config': config})
 
 silq_env_var = 'SILQ_EXP_FOLDER'
 
-if 'ipykernel' in sys.modules:
+if 'ipykernel' in sys.modules and using_ipython():
     # Load iPython magic (configured via qc.config.core.register_magic)
     from qcodes.utils.magic import register_magic_class
 


### PR DESCRIPTION
Originally the only check was if `ipykernel` was in `sys.modules`.
While this usually works in detecting if we're using ipython, it fails when a new process is started using multiprocessing. In this situation `ipykernel` exists, but the process is not using ipython.

This modification was needed for https://github.com/nulinspiratie/Qcodes/pull/79