### PR TITLE
fix:Remove clear temporary settings at end of measurement

### DIFF
--- a/silq/__init__.py
+++ b/silq/__init__.py
@@ -509,6 +509,24 @@ def _stop_layout(close_trace_file=True):
     except (KeyError, TypeError):
         logger.warning(f'No layout found to stop')
 
+
+def _clear_all_acquisition_parameter_settings(measurement=None):
+    if measurement is None:
+        measurement = qc.active_measurement()
+
+    if isinstance(measurement, qc.loops.ActiveLoop):
+        for action in measurement:
+            if isinstance(action, qc.loops.ActiveLoop):
+                _clear_all_acquisition_parameter_settings(action)
+            elif isinstance(action, SettingsClass):
+                logger.info(f'End-of-measurement: clearing settings for {action}')
+                action.clear_settings()
+    else:
+        for action_indices, action in measurement.actions.items():
+            if isinstance(action, SettingsClass):
+                logger.info(f'End-of-measurement: clearing settings for {action}')
+                action.clear_settings()
+
 qc.Measurement.final_actions = [
     _stop_layout,
 ]

--- a/silq/__init__.py
+++ b/silq/__init__.py
@@ -509,27 +509,8 @@ def _stop_layout(close_trace_file=True):
     except (KeyError, TypeError):
         logger.warning(f'No layout found to stop')
 
-
-def _clear_all_acquisition_parameter_settings(measurement=None):
-    if measurement is None:
-        measurement = qc.active_measurement()
-
-    if isinstance(measurement, qc.loops.ActiveLoop):
-        for action in measurement:
-            if isinstance(action, qc.loops.ActiveLoop):
-                _clear_all_acquisition_parameter_settings(action)
-            elif isinstance(action, SettingsClass):
-                logger.info(f'End-of-measurement: clearing settings for {action}')
-                action.clear_settings()
-    else:
-        for action_indices, action in measurement.actions.items():
-            if isinstance(action, SettingsClass):
-                logger.info(f'End-of-measurement: clearing settings for {action}')
-                action.clear_settings()
-
 qc.Measurement.final_actions = [
     _stop_layout,
-    _clear_all_acquisition_parameter_settings
 ]
 
 


### PR DESCRIPTION
This PR removes the clearing of temporary acquisition parameter settings for the new Measurement.
So the following won't work anymore in the new Measurement:
```Python
NMR_parameter.temporary_settings(samples=200)
```
The reason is that keeping the ability to implement this is rather annoying to program, and its functionality is superseded by `Measurement.mask`
