### PR TITLE
add envelope_IQ to keysight e8267D interface

### DIFF
--- a/silq/instrument_interfaces/keysight/E8267D_interface.py
+++ b/silq/instrument_interfaces/keysight/E8267D_interface.py
@@ -88,7 +88,7 @@ class E8267DInterface(InstrumentInterface):
                       "I and Q pulses are extended by the envelope padding "
                       "before (after) the pulse start (stop) time. "
                       "If False, the marker pulse starts before (after) the pulse start (stop) "
-                      "time, and the IQ pulses start (stop) at the pulse start (stop) time."
+                      "time, and the IQ pulses starts (stops) at the pulse start (stop) time."
                       "This means that there might be some leakage at the carrier frequency "
                       "when the IQ is zero, but the marker pulse is still high."
         )
@@ -203,6 +203,8 @@ class E8267DInterface(InstrumentInterface):
                                if pulse.frequency_sideband is not None else None
                                for pulse in self.pulse_sequence}
 
+        # Ramp mode does not work with envelope IQ since the output can only be
+        # turned off via gating (0V on ramp input corresponds to a pulse at carrier)
         assert self.FM_mode() != 'ramp' or self.envelope_IQ(), \
             "Cannot use 'ramp' FM mode while envelope_IQ == False"
 


### PR DESCRIPTION
Adds the parameter `microwave_interface.envelope_IQ` to the Keyisght E8267D microwave interface.
By default (`envelop_IQ=True`), the envelope padding is applied to the IQ inputs, while the marker pulses are the length of the actual pulse.
When `envelope_IQ = False`, the envelope padding is instead applied to the marker pulses, and the IQ inputs are only nonzero for the duration of the pulses.
This feature is useful if you want multiple pulses that are more closely spaced than the envelope padding.

Note that to avoid pulse overlaps, any overlapping marker pulses are merged into a single longer marker pulse.

@RostyslavSavytskyy I think we should merge this PR before #233 since it is a fairly small PR and could otherwise lead to conflicts
