### PR TITLE
added deletion of Q character for RB sequences

### DIFF
--- a/silq/tools/circuit_tools.py
+++ b/silq/tools/circuit_tools.py
@@ -22,6 +22,7 @@ def convert_circuit(circuit, target_type: Type = str):
     elif isinstance(circuit, str):
         # Replace [] by identity gate
         expanded_circuit = circuit.replace('[]', 'Gi')
+        expanded_circuit = circuit.replace('Q', '')
 
         # Expand any expressions ({gates})^exponent
         expand_subcircuit = lambda match: match.group(0).replace(


### PR DESCRIPTION
In RB sequences for Randomized Benchmarking there is an additional Q character that is needed to properly use pygsti analysis of the results later. But to measure first, we need to get rid of it.