### PR TITLE
PCDDS revert absolute / relative phase

### DIFF
--- a/silq/instrument_interfaces/keysight/fpga_interfaces/PCDDS_interface.py
+++ b/silq/instrument_interfaces/keysight/fpga_interfaces/PCDDS_interface.py
@@ -152,11 +152,8 @@ class SinePulseImplementation(PulseImplementation):
     pulse_class = SinePulse
 
     def implement(self, *args, **kwargs):
-        if self.pulse.phase_reference == 'absolute':
-            phase = 360 * ((self.pulse.frequency * self.pulse.t_start) % 1)
-            phase += self.pulse.phase
-        else:
-            phase = self.pulse.phase
+        # TODO distinguish between abolute / relative phase
+        phase = self.pulse.phase
 
         return {'instr': 'sine',
                 'freq': self.pulse.frequency,


### PR DESCRIPTION
Temporarily revert the PCDDS phase reference such that it is always phase coherent, because now it's the wrong way around. 
At least until we figure out #248 