### PR TITLE
Fix: AWG indexing issues and inverted connection

### DIFF
--- a/silq/instrument_interfaces/keysight/Keysight_SD_AWG_interface.py
+++ b/silq/instrument_interfaces/keysight/Keysight_SD_AWG_interface.py
@@ -145,7 +145,7 @@ class Keysight_SD_AWG_Interface(InstrumentInterface):
                                  duration=15e-6,
                                  connection=trigger_connection)]
 
-    def setup(self, error_threshold=1e-6, **kwargs):
+    def setup(self, output_connections, error_threshold=1e-6, **kwargs):
         # TODO: startdelay of first waveform
         # TODO: Handle sampling rates different from default
         # TODO: think about how to configure queue behaviour (cyclic/one shot for example)
@@ -159,7 +159,7 @@ class Keysight_SD_AWG_Interface(InstrumentInterface):
 
         self.setup_trigger()
 
-        self.waveforms, self.waveform_queue = self.create_waveforms(error_threshold)
+        self.waveforms, self.waveform_queue = self.create_waveforms(error_threshold, output_connections=output_connections)
 
         self.load_waveforms(self.waveforms)
 
@@ -208,13 +208,27 @@ class Keysight_SD_AWG_Interface(InstrumentInterface):
             if trigger_source == 'trig_in':
                 self.instrument.trigger_direction('in')
 
-    def create_waveforms(self, error_threshold):
+    def create_waveforms(self, error_threshold, output_connections):
         waveform_queue = {ch: [] for ch in self.channel_selection()}
 
         # Sort the list of waveforms for each channel and calculate delays or
         # throw error on overlapping waveforms.
         for channel in self.active_instrument_channels:
-            default_sampling_rate = self.default_sampling_rates()[channel.id]
+            idx = channel.id
+            if not self.instrument.zero_based_channels:
+                idx -= 1
+            connection = next(
+                c for c in output_connections
+                if c.output['channel'].name == channel.name
+            )
+            # Inactive voltage should be high if input channel is inverted
+            # e.g. triggers when voltage drops below value
+            if connection.input['channel'].invert:
+                inactive_voltage = 1.5
+            else:
+                inactive_voltage = 0
+
+            default_sampling_rate = self.default_sampling_rates()[idx]
             prescaler = 0 if default_sampling_rate == 500e6 else int(
                 100e6 / default_sampling_rate)
 
@@ -243,7 +257,7 @@ class Keysight_SD_AWG_Interface(InstrumentInterface):
                     samples_start_0V = max(int(round(t * clock_rate)),
                                            total_samples)
                     samples_0V = (pulse_samples_start - samples_start_0V) * default_sampling_rate / clock_rate
-                    waveform_0V = self.create_DC_waveform(voltage=0,
+                    waveform_0V = self.create_DC_waveform(voltage=inactive_voltage,
                                                           samples=samples_0V,
                                                           prescaler=prescaler,
                                                           t_start=t)
@@ -281,7 +295,7 @@ class Keysight_SD_AWG_Interface(InstrumentInterface):
                 final_samples = int(
                     round(self.pulse_sequence.duration * clock_rate))
                 remaining_samples = (final_samples - total_samples) * default_sampling_rate / clock_rate
-                waveform_0V = self.create_DC_waveform(voltage=0,
+                waveform_0V = self.create_DC_waveform(voltage=inactive_voltage,
                                                       samples=remaining_samples,
                                                       prescaler=prescaler,
                                                       t_start=t)
@@ -703,8 +717,9 @@ class TriggerPulseImplementation(PulseImplementation):
         prescaler = 1
         samples = int(self.pulse.duration * sampling_rate)
         if samples < instrument.waveform_minimum:
-            logger.warning(f'Trigger pulse {self.pulse} too short, setting to '
-                           f'minimum duration of 15 samples')
+            logger.warning(f'SD_AWG trigger pulse {self.pulse} duration {self.pulse.duration} too short: '
+                           f'{samples} < {instrument.waveform_minimum} samples'
+                           ', setting to minimum duration of 15 samples')
             samples = 15
 
         # Set max cycles to 1 since trigger pulses should be very short


### PR DESCRIPTION
Fixes another minor issue regarding keysight indexing caused by `default_sampling_rates` still having hard-coded zero-based indexing.

Also adds the option for triggering lines that have an inverted connection (e.g. Pulseblaster DDS)