### PR TITLE
Add setpoint_labels to DCSweepParameter

### DIFF
--- a/silq/parameters/acquisition_parameters.py
+++ b/silq/parameters/acquisition_parameters.py
@@ -929,6 +929,14 @@ class DCSweepParameter(AcquisitionParameter):
         return names
 
     @property_ignore_setter
+    def setpoint_labels(self):
+        iter_sweep_parameters = reversed([p.capitalize() for p in self.sweep_parameters.keys()])
+        labels = tuple(iter_sweep_parameters),
+        if self.trace_pulse.enabled:
+            labels += (('Time',),)
+        return labels
+
+    @property_ignore_setter
     def setpoint_units(self):
         setpoint_units = (('V',) * len(self.sweep_parameters),)
         if self.trace_pulse.enabled:

--- a/silq/parameters/acquisition_parameters.py
+++ b/silq/parameters/acquisition_parameters.py
@@ -930,7 +930,8 @@ class DCSweepParameter(AcquisitionParameter):
 
     @property_ignore_setter
     def setpoint_labels(self):
-        iter_sweep_parameters = reversed([p.capitalize() for p in self.sweep_parameters.keys()])
+        iter_sweep_parameters = reversed(
+            [(p if p.isupper() else p.capitalize()) for p in self.sweep_parameters.keys()])
         labels = tuple(iter_sweep_parameters),
         if self.trace_pulse.enabled:
             labels += (('Time',),)


### PR DESCRIPTION
This is needed to prevent an error when using this parameter in a measurement context where setpoints are saved.