### PR TITLE
fixes the issue when saving pulse traces as well

### DIFF
--- a/silq/analysis/analysis.py
+++ b/silq/analysis/analysis.py
@@ -173,8 +173,8 @@ def find_high_low(
     if skip_pts > 0:
         traces = [trace[:, skip_pts:] for trace in traces]
 
-    # Turn list of 2D traces into a single 2D array
-    traces = np.ravel(traces)
+    # Turn list of 2D traces into a single 1D array
+    traces = np.concatenate([np.ravel(trace) for trace in traces])
 
     # Retrieve properties from config.analysis
     analysis_config = config.get("analysis", {})


### PR DESCRIPTION
In composite pulse sequences if you want to save also the traces of the applied pulses (plunge) and not just of the "read_initialize", the function (find_high_low) that determines the threshold voltage crushes due to the different sizes of the traces in each pulse. This modification quickly fixes the bug, but then the find_high_low function uses all traces to determine the threshold voltage which is useless. So we either need to determine the threshold voltage only when it is not set manually or be able to extract an use the traces only from read_initialize as it was done in non-composite parameters and pulse sequences.

**UPDATE**
It causes further crashes in the analysis, apparently composite analysis cannot handle the option when we save also traces that do not need to be analyzed.