### PR TITLE
fixes timing issues with triggering

### DIFF
--- a/silq/instrument_interfaces/spincore/PulseBlasterESRPRO_interface.py
+++ b/silq/instrument_interfaces/spincore/PulseBlasterESRPRO_interface.py
@@ -153,7 +153,8 @@ class PulseBlasterESRPROInterface(InstrumentInterface):
 
         # Add final instructions
         # Wait until end of pulse sequence
-        wait_duration = self.pulse_sequence.duration + self.pulse_sequence.final_delay - t
+        # If the first pulse starts at t > 0, bridge the gap with another wait for this time
+        wait_duration = self.pulse_sequence.duration + self.pulse_sequence.final_delay + sorted(t_list)[0] - t
 
         if wait_duration > 0:
             wait_cycles = round(wait_duration * sample_rate)

--- a/silq/instrument_interfaces/spincore/PulseBlasterESRPRO_interface.py
+++ b/silq/instrument_interfaces/spincore/PulseBlasterESRPRO_interface.py
@@ -154,6 +154,8 @@ class PulseBlasterESRPROInterface(InstrumentInterface):
         # Add final instructions
         # Wait until end of pulse sequence
         # If the first pulse starts at t > 0, bridge the gap with another wait for this time
+        # Used to be the commented line (see PR 281). If the PulseBlaster has triggering issues, try reverting this line.
+        # wait_duration = self.pulse_sequence.duration + self.pulse_sequence.final_delay - t
         wait_duration = self.pulse_sequence.duration + self.pulse_sequence.final_delay + sorted(t_list)[0] - t
 
         if wait_duration > 0:


### PR DESCRIPTION
In the cases when AWG does not demand a trigger for the first pulse in its sequence (e.g. arbstudio), a pulseblaster needs to wait this additional time between the end (start) of the sequence and the second pulse. Otherwise, the next trigger (for the second pulse) will appear right after the trigger in the end of the sequence, hence cutting out the first pulse, e.g. pre-delay in the plunge pulse is completely gone and is defined only by pulse_sequence.final_delay.   