### PR TITLE
Enable single-writer multiple-reader access to trace files.

### DIFF
--- a/silq/meta_instruments/layout.py
+++ b/silq/meta_instruments/layout.py
@@ -1658,7 +1658,7 @@ class Layout(Instrument):
         # Create new hdf5 file
         filepath = os.path.join(folder, f'{name}.hdf5')
         assert not os.path.exists(filepath), f"Trace file already exists: {filepath}"
-        file = h5py.File(filepath, 'w')
+        file = h5py.File(filepath, 'w', libver='latest')
 
         # Save metadata to traces file
         file.attrs['sample_rate'] = self.sample_rate()

--- a/silq/meta_instruments/layout.py
+++ b/silq/meta_instruments/layout.py
@@ -1702,6 +1702,7 @@ class Layout(Instrument):
                                           chunks=True, compression='gzip',
                                           compression_opts=compression)
         file.flush()
+        file.swmr_mode = True  # Enable multiple readers to access this process
         return file
 
     def save_traces(self,

--- a/silq/tools/trace_tools.py
+++ b/silq/tools/trace_tools.py
@@ -53,7 +53,7 @@ def load_traces(dataset: qc.DataSet, name: str = None, mode: str = "r"):
         trace_filename = filtered_trace_filenames[0]
 
     trace_filepath = os.path.join(traces_path, trace_filename)
-    trace_file = h5py.File(trace_filepath, mode)
+    trace_file = h5py.File(trace_filepath, mode, swmr=True)
     return trace_file
 
 


### PR DESCRIPTION
Fixes #224.

By using the latest version of hdf5 we gain access to some extra features, including single-writer multiple-reader (SWMR) mode.
We may wish to specify the exact version we want to use, going forward, to ensure backwards compatibility is more easily assured.

- [x] Test that I can read from a live trace file as it changes.
- [x] Verify the integrity of the traces (compare locally acquired version to version recovered from file)
- [x] I also checked that loading h5py files from previous library versions works well.
- [x] Speed performance, actually seems to have improved
    - Before
        - Storing 600,000 points takes ~ 260 +- 58 ms.
        - Storing 1500 points takes ~5.7 +- 4.7 ms
    - After 
        - Storing 600,000 points takes ~ 230 +- 50 ms.
        - Storing 1500 points takes ~1 +- 4 ms