### PR TITLE
Fix the setpoint shapes for fast 1D acquisitions.

### DIFF
--- a/silq/parameters/acquisition_parameters.py
+++ b/silq/parameters/acquisition_parameters.py
@@ -861,7 +861,7 @@ class DCSweepParameter(AcquisitionParameter):
             sweep_voltages = sweep_dict.sweep_voltages
             if sweep_dict.offset_parameter is not None:
                 sweep_voltages = sweep_voltages + sweep_dict.offset_parameter.get_latest()
-            setpoints = (convert_setpoints(sweep_voltages),),
+            setpoints = (convert_setpoints(sweep_voltages)),
 
         elif len(self.sweep_parameters) == 2:
             inner_sweep_dict = next(iter_sweep_parameters)


### PR DESCRIPTION
Fix a small bug (typo) that prevented the qcodes Measurement from properly creating set_arrays for 1D sweeps.

Test code:
---
# 1D
```python
from silq.parameters.acquisition_parameters import DCSweepParameter
fast_dc = DCSweepParameter()
D1 = Parameter('D1', get_cmd=None, set_cmd=None, initial_value=0)
D2 = Parameter('D2', get_cmd=None, set_cmd=None, initial_value=0)

fast_dc.use_ramp = True

fast_dc.trace_pulse.enabled = False

fast_dc.sweep_parameters.clear()
fast_dc.add_sweep('D1', np.linspace(-100e-3, 100e-3, 51), 'dummy1', offset_parameter=D1)

fast_dc.setup()


with Measurement('test_fast_dc') as msmt:
    for _ in Sweep(D1.sweep(0, 1, step=200e-3), restore=True):
            msmt.measure(fast_dc)
```

--- 
# 2D
```python
from silq.parameters.acquisition_parameters import DCSweepParameter
fast_dc = DCSweepParameter()
D1 = Parameter('D1', get_cmd=None, set_cmd=None, initial_value=0)
D2 = Parameter('D2', get_cmd=None, set_cmd=None, initial_value=0)

fast_dc.use_ramp = True

fast_dc.trace_pulse.enabled = False

fast_dc.sweep_parameters.clear()
fast_dc.add_sweep('D1', np.linspace(-100e-3, 100e-3, 51), 'dummy1', offset_parameter=D1)
fast_dc.add_sweep('D2', np.linspace(-100e-3, 100e-3, 51), 'dummy2', offset_parameter=D2)

fast_dc.setup()


with Measurement('test_fast_dc') as msmt:
    for _ in Sweep(D1.sweep(0, 1, step=200e-3), restore=True):
        for _ in Sweep(D2.sweep(0, 1, step=200e-3), restore=True):
            msmt.measure(fast_dc)
```