### PR TITLE
Fix calculation of sweep values when using window

### DIFF
--- a/silq/tools/parameter_tools.py
+++ b/silq/tools/parameter_tools.py
@@ -86,7 +86,7 @@ class SweepDependentValues(SweepValues):
 
         if self.num is None:
             step = self.determine_step(self.parameter)
-            num = int(round(window / step))
+            num = int(round(window / step)) + 1
         else:
             num = self.num
 


### PR DESCRIPTION
There was a fence-post error that caused window sweeps to be calculated using the wrong number of points. This isn't normally important unless you depend on an exact number of points being measured (e.g. when stitching together multiple fast DC acquisitions.)