### PR TITLE
Adjust DC sweep plot "read point"

### DIFF
--- a/silq/tools/plot_tools.py
+++ b/silq/tools/plot_tools.py
@@ -918,6 +918,7 @@ class DCSweepPlot(ScanningPlot):
                     self._update_point()
                 else:
                     result_config['y'] = result
+                    result_config['x'] = self.parameter.setpoints[k][0]
 
         super().update_plot()
 

--- a/silq/tools/plot_tools.py
+++ b/silq/tools/plot_tools.py
@@ -888,23 +888,20 @@ class DCSweepPlot(ScanningPlot):
                     if self.point is not None:
                         new_x = self.x_gate.get_latest()
                         new_y = self.x_gate.get_latest()
-
+                        A = self.parameter.trace_pulse.amplitude
                         connection = self.layout.get_connection(
                             self.parameter.trace_pulse.connection_label)
 
-                        if isinstance(connection, CombinedConnection):
-                            connections = connection.connections
-                            scales = {c.label: s for c, s in
-                                      zip(connections, connection.scale)}
-                        else:
-                            scales = {connection.label:connection.scale}
-        
                         # Add scaled offset for "read point" in diagram.
-                        A = self.parameter.trace_pulse.amplitude
-                        if self.x_gate.name in scales:
-                            new_x += A * scales[self.x_gate.name]
-                        if self.y_gate.name in scales:
-                            new_y += A * scales[self.y_gate.name]
+                        # Since pulse is already scaled to device voltages, we
+                        # only need to apply the combination scaling.
+                        if isinstance(connection, CombinedConnection):
+                            for con, scale in zip(connection.connections,
+                                                  connection.scale):
+                                if self.x_gate.name == con.label:
+                                    new_x += A * scale
+                                elif self.y_gate.name == con.label:
+                                    new_y += A * scale
 
                         self.point.set_xdata(new_x)
                         self.point.set_ydata(new_y)

--- a/silq/tools/plot_tools.py
+++ b/silq/tools/plot_tools.py
@@ -800,6 +800,7 @@ class DCSweepPlot(ScanningPlot):
         **kwargs: Additional kwargs to `InteractivePlot` and ``MatPlot``.
     """
     gate_mapping = {}
+    trace_ylim = (-0.1, 1.3)
     point_color = 'r'
 
     # DCSweepParameter type
@@ -827,7 +828,7 @@ class DCSweepPlot(ScanningPlot):
         super().__init__(parameter, subplots=subplots, **kwargs)
 
         if parameter.trace_pulse.enabled:
-            self[1].set_ylim(-0.1, 1.3)
+            self[1].set_ylim(*self.trace_ylim)
 
         self.actions = [MoveGates(self)]
 


### PR DESCRIPTION
This PR moves the central dot to the location where the trace_pulse is actually taken. Typically this is set to the read location.