### PR TITLE
Expand mock interfaces in SilQ to enable thorough simulation

### DIFF
--- a/silq/tests/mocks/__init__.py
+++ b/silq/tests/mocks/__init__.py
@@ -38,4 +38,8 @@ def add_mock_interfaces():
         'module': 'silq.tests.mocks.mock_interfaces',
         'class': 'MockDigitizerInterface'
     }
+    instrument_interfaces['MockMicrowaveInstrument'] = {
+        'module': 'silq.tests.mocks.mock_interfaces',
+        'class': 'MockMicrowaveInterface'
+    }
 

--- a/silq/tests/mocks/mock_instruments/__init__.py
+++ b/silq/tests/mocks/mock_instruments/__init__.py
@@ -1,3 +1,4 @@
 from .mock_trigger_instrument import MockTriggerInstrument
 from .mock_awg_instrument import MockAWGInstrument
 from .mock_digitizer_instrument import MockDigitizerInstrument
+from .mock_microwave_instrument import MockMicrowaveInstrument

--- a/silq/tests/mocks/mock_instruments/mock_microwave_instrument.py
+++ b/silq/tests/mocks/mock_instruments/mock_microwave_instrument.py
@@ -1,0 +1,5 @@
+from qcodes import Instrument
+
+
+class MockMicrowaveInstrument(Instrument):
+    pass

--- a/silq/tests/mocks/mock_interfaces/__init__.py
+++ b/silq/tests/mocks/mock_interfaces/__init__.py
@@ -1,4 +1,5 @@
 from .mock_interface import MockInterface
 from .mock_trigger_interface import MockTriggerInterface
 from .mock_AWG_interface import MockAWGInterface
+from .mock_microwave_interface import MockMicrowaveInterface
 from .mock_digitizer_interface import MockDigitizerInterface

--- a/silq/tests/mocks/mock_interfaces/mock_AWG_interface.py
+++ b/silq/tests/mocks/mock_interfaces/mock_AWG_interface.py
@@ -1,6 +1,6 @@
 from .mock_interface import MockInterface
 from silq.instrument_interfaces import Channel
-from silq.pulses import DCPulse, SinePulse, PulseImplementation
+from silq.pulses import DCPulse, DCRampPulse, SinePulse, PulseImplementation
 
 
 class MockAWGInterface(MockInterface):
@@ -13,7 +13,7 @@ class MockAWGInterface(MockInterface):
         self._output_channels = {
             f'ch{k}': Channel(instrument_name=self.instrument_name(),
                               name=f'ch{k}', id=k, output=True)
-            for k in [1,2]
+            for k in range(1, 11)
         }
         self._channels = {
             **self._output_channels,
@@ -24,6 +24,10 @@ class MockAWGInterface(MockInterface):
         self.pulse_implementations = [
             DCPulseImplementation(pulse_requirements=[('amplitude', {'min': -1,
                                                                      'max': 1})]),
+            DCRampPulseImplementation(pulse_requirements=[
+                ('amplitude_start', {'min': -1, 'max': 1}),
+                ('amplitude_stop', {'min': -1, 'max': 1}),
+            ]),
             SinePulseImplementation(pulse_requirements=[('frequency', {'max': 500e6}),
                                                         ('amplitude', {'min': -1,
                                                                        'max': 1})])
@@ -42,6 +46,9 @@ class MockAWGInterface(MockInterface):
 
 class DCPulseImplementation(PulseImplementation):
     pulse_class = DCPulse
+
+class DCRampPulseImplementation(PulseImplementation):
+    pulse_class = DCRampPulse
 
 
 class SinePulseImplementation(PulseImplementation):

--- a/silq/tests/mocks/mock_interfaces/mock_microwave_interface.py
+++ b/silq/tests/mocks/mock_interfaces/mock_microwave_interface.py
@@ -1,0 +1,139 @@
+from .mock_interface import MockInterface
+from silq.instrument_interfaces import Channel
+from silq.pulses import SinePulse, PulseImplementation, FrequencyRampPulse, DCPulse
+from qcodes import Parameter
+import numpy as np
+
+
+class MockMicrowaveInterface(MockInterface):
+    def __init__(self, instrument_name, **kwargs):
+        super().__init__(instrument_name, **kwargs)
+
+        # Define instrument channels
+        # - Two output channels (ch1 and ch2)
+        # - One input trigger channel (trig_in)
+        self._output_channels = {
+            f'RF_out': Channel(instrument_name=self.instrument_name(),
+                              name='RF_out', id=0, output=True)
+        }
+        self._input_channels = {
+            label: Channel(instrument_name=self.instrument_name(),
+                              name=label, id=k, input=True)
+            for k, label in enumerate(['I', 'Q', 'pulse_mod'])
+        }
+        self._channels = {
+            **self._output_channels,
+            **self._input_channels,
+        }
+
+        self.pulse_implementations = [
+            SinePulseImplementation(
+                pulse_requirements=[
+                    ('frequency', {'max': 500e6}),
+                    ('power', {'min': -150, 'max': 25}),
+                ]),
+
+            FrequencyRampPulseImplementation(
+                pulse_requirements=[
+                    ('frequency_start', {'min': 20e9,'max': 44e9}),
+                    ('frequency_stop', {'min': 20e9, 'max': 44e9}),
+                    ('power', {'min': -150,'max': 25})
+                ]),
+        ]
+
+        self.carrier_frequency = Parameter('carrier', unit='Hz', set_cmd=None)
+
+    def get_additional_pulses(self, connections):
+        """Additional pulses needed by instrument after targeting of main pulses
+
+                Args:
+                    connections: List of all connections in the layout
+
+                Returns:
+                    List of additional pulses, such as IQ modulation pulses
+                """
+        if not self.pulse_sequence:
+            return []
+
+        frequency_settings = self.determine_instrument_settings()
+
+        additional_pulses = []
+        phases = []
+        frequencies = []
+        for pulse in self.pulse_sequence:
+            if isinstance(pulse, SinePulse):
+                frequencies.append(pulse.frequency)
+                phases.append(pulse.phase)
+            elif isinstance(pulse, FrequencyRampPulse):
+                frequencies.append(pulse.frequency_start)
+                frequencies.append(pulse.frequency_stop)
+                phases.append(pulse.phase)
+
+        phases = set(phases)
+        frequencies = set(frequencies)
+        if len(phases) > 1 or len(frequencies) > 1:
+            f0 = np.mean(frequencies)
+            self.carrier_frequency(f0)
+            for pulse in self.pulse_sequence:
+                additional_pulses.extend(
+                    [SinePulse('I_sideband', frequency=f0 - pulse.frequency,
+                               duration=pulse.duration, t_start=pulse.t_start,
+                               phase=pulse.phase(),
+                               connection_requirements={
+                                   'input_instrument': self.instrument_name(),
+                                   'input_channel': 'I'}),
+                     SinePulse('Q_sideband', frequency=f0 - pulse.frequency,
+                               duration=pulse.duration, t_start=pulse.t_start,
+                               phase=pulse.phase()-90,
+                               connection_requirements={
+                                   'input_instrument': self.instrument_name(),
+                                   'input_channel': 'I'})
+                     ]
+                )
+        else:
+            self.carrier_frequency(next(frequencies))
+
+
+        # # Ensure marker pulses are not overlapping
+        # marker_pulses = [p for p in additional_pulses if
+        #                  isinstance(p, MarkerPulse)]
+        # if marker_pulses:
+        #     marker_pulses = sorted(marker_pulses, key=lambda p: p.t_start)
+        #     current_pulse = marker_pulses[0]
+        #     merged_marker_pulses = [current_pulse]
+        #     for pulse in marker_pulses[1:]:
+        #         if pulse.t_start <= current_pulse.t_stop:
+        #             # Marker pulse overlaps with previous pulse
+        #             current_pulse.t_stop = max(pulse.t_stop,
+        #                                        current_pulse.t_stop)
+        #         else:
+        #             # Pulse starts after previous pulse
+        #             merged_marker_pulses.append(pulse)
+        #             current_pulse = pulse
+        #     nonmarker_pulses = [p for p in additional_pulses if
+        #                         not isinstance(p, MarkerPulse)]
+        #     additional_pulses = [*merged_marker_pulses, *nonmarker_pulses]
+
+        return additional_pulses
+
+
+    def setup(self, **kwargs):
+        pass
+
+    def start(self):
+        pass
+
+    def stop(self):
+        pass
+
+# Define pulse implementations
+
+class DCPulseImplementation(PulseImplementation):
+    pulse_class = DCPulse
+
+
+class SinePulseImplementation(PulseImplementation):
+    pulse_class = SinePulse
+
+class FrequencyRampPulseImplementation(PulseImplementation):
+    pulse_class = FrequencyRampPulse


### PR DESCRIPTION
It is often advantageous being able to test new features outside of a real experimental setup, especially those that utilise the layout or AcquisitionParameters.

This PR adds key features to the AWG and digitizer instruments and their interfaces including
- [x] DCRampPulse added to AWG
- [x] capture_full_trace added to digitizer
- [x] More channels (10 total) added to AWG for convenience (to mimic a 'real' setup, multiple AWGs with ~4 channels should be used)
- [x] Add microwave mock interface and instrument (good for testing that the correct modulation pulses are being requested)