### PR TITLE
Robust Phase Estimation (RPE)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -31,6 +31,7 @@ extras = {
     'slacker': ('slacker', '0.9.42'),
     'theano': ('theano', '0.9'),
     'keras': ('keras', '2.0.8'),
+    'pygsti': ('pygsti', '0.9.9.3'),
     'qutip': ('qutip', '4.5.0')
     # 'ipympl': ('ipympl', '0.0.3')
 

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ extras = {
     'slacker': ('slacker', '0.9.42'),
     'theano': ('theano', '0.9'),
     'keras': ('keras', '2.0.8'),
-    'pygsti': ('pygsti', '0.9.9.3'),
+    'pygsti': ('pygsti', '0.9.10'),
     'qutip': ('qutip', '4.5.0')
     # 'ipympl': ('ipympl', '0.0.3')
 

--- a/silq/analysis/__init__.py
+++ b/silq/analysis/__init__.py
@@ -1,2 +1,3 @@
 from .analysis import *
 from .fit_toolbox import *
+from .rpe import *

--- a/silq/analysis/rpe.py
+++ b/silq/analysis/rpe.py
@@ -1,0 +1,149 @@
+import pygsti
+from quapack.pyRPE import RobustPhaseEstimation
+from quapack.pyRPE.quantum import Q
+import numpy as np
+from ..tools.general_tools import count_num_decimal_places
+from ..tools.circuit_tools import make_gate_sin_circ, make_gate_cos_circ
+
+from matplotlib import pyplot as plt
+
+__all__ = ['analyse_RPE', 'rpe_get_best_estimate', 'plot_rpe_results']
+
+def analyse_RPE(dataset, gate_name, max_length: int = None):
+    """Finds the estimated rotation angle of an operation from an RPE experiment.
+
+    Args:
+        dataset: A pygsti dataset
+        gate_name: The name of the operation being tested.
+        max_length: The maximum circuit depth to perform the analysis up to.
+                    The analysis automatically calculates an estimated angle for
+                    all powers of 2 up to max_length.
+
+    Returns:
+
+    """
+    if max_length is None:
+        max_length = len(max(dataset.keys()))
+
+    rpe_container = Q()
+
+    log2_max_length = int(np.log2(max_length))
+    max_lengths = [2 ** i for i in range(log2_max_length + 1)]
+
+    for length in max_lengths:
+        cos_circ = make_gate_cos_circ(length, gate_name)
+        sin_circ = make_gate_sin_circ(length, gate_name)
+
+        rpe_container.process_cos(length, (
+        int(dataset[cos_circ]['0']), int(dataset[cos_circ]['1'])))
+        rpe_container.process_sin(length, (
+        int(dataset[sin_circ]['1']), int(dataset[sin_circ]['0'])))
+
+    rpe_analyzer = RobustPhaseEstimation(rpe_container)
+    return rpe_container, rpe_analyzer
+
+def rpe_get_best_estimate(rpe_analyzer:RobustPhaseEstimation, include_precision=False, **kwargs):
+    """Gives the best estimate
+
+    Args:
+        rpe_analyzer: A RobustPhaseEstimation instance
+        include_precision: If True, returns a tuple of the estimated rotation angle
+         and the approximate precision to which it is known.
+
+        **kwargs:
+
+    Returns:
+
+    """
+    best_idx = rpe_analyzer.check_unif_local(**kwargs)
+
+    if include_precision:
+        precision = np.pi/(2 ** (best_idx + 1))
+        return rpe_analyzer.angle_estimates[best_idx], precision
+
+    return rpe_analyzer.angle_estimates[best_idx]
+
+def plot_rpe_results(rpe_analyzer, target_angle = 0, plot_delta=False,
+                     unit = 'deg', ax=None, **kwargs):
+    """
+
+    Args:
+        rpe_analyzer:
+        ax:
+
+    Returns:
+
+    """
+
+    if ax is None:
+        fig = plt.figure()
+        ax = fig.gca()
+    max_lengths = np.array([2 ** i for i in range(len(rpe_analyzer.angle_estimates))])
+    yerrs = np.pi/(2*max_lengths) # PRL 118, 190502 (2017)
+    best_idx = rpe_analyzer.check_unif_local(**kwargs)
+    (best_angle, precision) = rpe_get_best_estimate(rpe_analyzer, include_precision=True)
+    n_digits = count_num_decimal_places(precision)
+
+    best_estimate = '{0:.{1}f}'.format(round(best_angle, n_digits), n_digits) + \
+                    '({0:.1g})'.format(round(precision, n_digits) * (10 ** n_digits))
+
+    best_estimate = '{0:.{1}f}'.format(round(best_angle, n_digits)/np.pi, n_digits)\
+                    + '({0:.1g})'.format(round(precision, n_digits)/np.pi * (10 ** n_digits))
+
+    if unit == 'deg':
+        scale = 180 / np.pi
+        yunit = r'($^\circ\!$)'
+    elif unit == 'rad':
+        scale = 1
+        yunit = r'(rad)'
+    elif unit == 'pi':
+        scale = 1 / np.pi
+        yunit = r'($\times \pi$)'
+    elif unit == '2pi':
+        scale = 1 / (2 * np.pi)
+        yunit = r'($\times 2\pi$)'
+
+
+
+    if plot_delta:
+        ax.plot(max_lengths, (rpe_analyzer.angle_estimates - target_angle) * scale,
+                marker='.', label=r'$\langle \theta \rangle = \pi\cdot$' + best_estimate)
+
+        ax.fill_between(max_lengths,
+                        y1=(rpe_analyzer.angle_estimates - target_angle - yerrs) * scale,
+                        y2=(rpe_analyzer.angle_estimates - target_angle + yerrs) * scale,
+                        alpha=0.5, zorder=-1,
+                        )
+
+        ax.axhline(0, c='k', zorder=-1, label=r'$\Delta \theta = 0$')
+
+        ylabel = r'$\Delta \theta$ ' + yunit
+    else:
+        ax.plot(max_lengths, rpe_analyzer.angle_estimates * scale,
+                marker='.', label=r'$\langle \theta \rangle = \pi\cdot$' + best_estimate)
+
+        ax.fill_between(max_lengths,
+                        y1=(rpe_analyzer.angle_estimates - yerrs) * scale,
+                        y2=(rpe_analyzer.angle_estimates + yerrs) * scale,
+                        alpha=0.5, zorder=-1,
+                        )
+
+        ax.axhline(target_angle * scale, c='k', zorder=-1,
+                   label=r'$\theta = \pi\cdot$' + f'{target_angle / np.pi}')
+
+        ylabel = r'$\theta$ ' + yunit
+
+
+    ax.set_xscale('log', base=2)
+    ax.set_xticks(max_lengths)
+    ax.set_xlabel('Number of gates in generation $N_k$')
+    ax.set_ylabel(ylabel)
+    ax.axvline(max_lengths[best_idx], lw=2, c='r', label='best estimate length')
+    ax.legend(loc='upper center')
+
+    plt.tight_layout()
+
+    return fig, ax
+
+    # plt.axhline(/np.pi, c='k', zorder=-1)
+    # plt.axhline((np.pi/2 + delta_y)/np.pi, c='k', zorder=-1)

--- a/silq/analysis/rpe.py
+++ b/silq/analysis/rpe.py
@@ -1,6 +1,10 @@
-import pygsti
-from quapack.pyRPE import RobustPhaseEstimation
-from quapack.pyRPE.quantum import Q
+try:
+    from quapack.pyRPE import RobustPhaseEstimation
+    from quapack.pyRPE.quantum import Q
+except ImportError:
+    raise ImportError('RPE tools need to be installed before use, '
+                      'see https://gitlab.com/quapack/pyrpe')
+
 import numpy as np
 from ..tools.general_tools import count_num_decimal_places
 from ..tools.circuit_tools import make_gate_sin_circ, make_gate_cos_circ

--- a/silq/analysis/rpe.py
+++ b/silq/analysis/rpe.py
@@ -7,7 +7,6 @@ except ImportError:
 
 import numpy as np
 from ..tools.general_tools import count_num_decimal_places
-from ..tools.circuit_tools import make_gate_sin_circ, make_gate_cos_circ
 
 from matplotlib import pyplot as plt
 
@@ -26,22 +25,25 @@ def analyse_RPE(dataset, gate_name, max_length: int = None):
     Returns:
 
     """
-    if max_length is None:
-        max_length = len(max(dataset.keys()))
-
     rpe_container = Q()
 
-    log2_max_length = int(np.log2(max_length))
-    max_lengths = [2 ** i for i in range(log2_max_length + 1)]
-
-    for length in max_lengths:
-        cos_circ = make_gate_cos_circ(length, gate_name)
-        sin_circ = make_gate_sin_circ(length, gate_name)
+    circuit_list = dataset.keys()
+    length = 1
+    while True:
+        if max_length is not None and length > max_length:
+            break
+        try:
+            cos_circ = next(circuit_list)
+            sin_circ = next(circuit_list)
+        except StopIteration:
+            break
 
         rpe_container.process_cos(length, (
         int(dataset[cos_circ]['0']), int(dataset[cos_circ]['1'])))
         rpe_container.process_sin(length, (
         int(dataset[sin_circ]['1']), int(dataset[sin_circ]['0'])))
+
+        length *= 2
 
     rpe_analyzer = RobustPhaseEstimation(rpe_container)
     return rpe_container, rpe_analyzer

--- a/silq/tools/circuit_tools.py
+++ b/silq/tools/circuit_tools.py
@@ -237,7 +237,9 @@ def analyse_circuit_results(
 
 
     target_model = exp_design.create_target_model()
-    outcome_labels = list(target_model.povms['Mdefault'].keys())
+    # Get unique set of outcome labels for this model (normally '0', '1', etc.)
+    outcome_labels = set(
+        [key for povm in target_model.povms.values() for key in povm.keys()])
     n_outcomes = len(outcome_labels)
 
     if outcomes_mapping is None:

--- a/silq/tools/circuit_tools.py
+++ b/silq/tools/circuit_tools.py
@@ -7,7 +7,6 @@ from pygsti.protocols.gst import GateSetTomographyDesign
 from pygsti.protocols.rpe import RobustPhaseEstimationDesign
 from pygsti.circuits import Circuit
 
-from silq import config
 from qcodes import DataArray
 
 def convert_circuit(circuit, target_type: Union[str, List[str], Circuit] = str,
@@ -83,6 +82,10 @@ def _get_experiment_dir(filepath: Union[str, Path],
     Raises:
         FileNotFoundError
     """
+    # Defer importing of silq config as circuit_tools is typically imported
+    # before the config is created.
+    from silq import config
+
     assert config_entry in config, f'config.{config_entry} does not exist.'
     assert isinstance(config[config_entry], str), \
         f"Config entry for experiment designs path must be a string and not " \

--- a/silq/tools/circuit_tools.py
+++ b/silq/tools/circuit_tools.py
@@ -173,9 +173,9 @@ def create_dataset(results, circuits:List[Circuit], path=None):
     """Create a pyGSTi DataSet from a results array.
 
     Args:
-        results: A dictionary of results with keys for each measurement outcome
-                ('0', '1' for 1Q, '00', '01' etc. for 2Q and so on).
-                The value of each entry will be an array of counts.
+        results: A nested dictionary of circuit results, with the summed counts
+                for each possible outcome. The dict value for each circuit is a
+                set of outcome_label-count pairs.
         circuits: An ordered list of the circuits, must be the same length as
                 the number of values in each dictionary entry.
         path: If set, write the resulting dataset to file at the specified path.
@@ -185,11 +185,6 @@ def create_dataset(results, circuits:List[Circuit], path=None):
     """
 
     dataset = pygsti.data.DataSet()
-
-    # Reconstruct results dictionary to use circuits as keys
-    # Each circuit has a number of outcomes (e.g. '0' or '1') with recorded counts
-    # results = {circuit: {outcome: results[outcome][circuit_idx] for outcome in results.keys()}
-    #                for circuit_idx, circuit in enumerate(circuits)}
 
     for k, circuit in enumerate(circuits):
         dataset.add_count_dict(circuit, results[circuit])
@@ -221,7 +216,10 @@ def analyse_circuit_results(
         circuits_axis: Specifies which axis distinguishes each circuit.
         outcomes_axis: Specifies which axis distinguishes each circuit outcome.
         outcomes_mapping: Optional, a mapping between each outcome and the index
-                    into the outcomes_arr on the outcomes_axis.
+                    into the outcomes_arr on the outcomes_axis. This is useful if
+                    the recorded results for each outcome aren't in binary order.
+                    Defualt mapping is from index i to its binary string
+                    representation, e.g. index 3 corresponds to outcome '11'.
 
     Returns:
         A dictionary of circuit results, with the summed counts for each

--- a/silq/tools/circuit_tools.py
+++ b/silq/tools/circuit_tools.py
@@ -247,8 +247,10 @@ def analyse_circuit_results(
 
     if outcomes_axis is None:
         # Find which axis hosts the distinct circuit outcomes
-        assert np.count_nonzero(np.array(outcomes_arr.shape) == n_outcomes) == 1,\
-        "Multiple axes were found with dimension that matches the number of " \
+        n_matching_axes = np.count_nonzero(
+            np.array(outcomes_arr.shape) == n_outcomes)
+        assert n_matching_axes == 1,\
+        f"{n_matching_axes} axes were found with dimension that matches the number of " \
         "expected outcomes. Please specify which axis distinguishes the circuit" \
         "outcomes."
 
@@ -257,8 +259,10 @@ def analyse_circuit_results(
 
     if circuits_axis is None:
         # Find which axis hosts the distinct circuit outcomes
-        assert np.count_nonzero(np.array(outcomes_arr.shape) == len(circuits)) == 1,\
-        "Multiple axes were found with dimension that matches the number of " \
+        n_matching_axes = np.count_nonzero(
+            np.array(outcomes_arr.shape) == len(circuits))
+        assert n_matching_axes == 1,\
+        f"{n_matching_axes} axes were found with dimension that matches the number of " \
         "circuits. Please specify which axis distinguishes the circuits."
 
         circuits_axis = np.argmin(np.array(outcomes_arr.shape), len(circuits))

--- a/silq/tools/circuit_tools.py
+++ b/silq/tools/circuit_tools.py
@@ -11,7 +11,7 @@ from qcodes import DataArray
 
 __all__ = ['convert_circuit', 'load_experiment_design', 'load_GST_circuits',
            'load_dataset', 'create_dataset', 'analyse_circuit_results',
-           'make_RPE_experiment']
+           'make_rpe_experiment']
 
 def convert_circuit(circuit, target_type: Union[str, List[str], Circuit] = str,
                     include_state_space_labels=True,

--- a/silq/tools/circuit_tools.py
+++ b/silq/tools/circuit_tools.py
@@ -18,18 +18,18 @@ def convert_circuit(circuit, target_type: Type = str):
         >>> convert_circuit('GxGi', target_type=list)
         ['Gx', 'Gi']
     """
-    from pygsti.objects.circuit import Circuit
+    from pygsti.circuits.circuit import Circuit
     
     # First convert all types to string
     if isinstance(circuit, Circuit):
         expanded_circuit = []
-        for gate in circuit.get_labels():
-            if gate.issimple():
-                expanded_circuit.append(gate.name)
-            elif str(gate) == '[]':
-                gate.append('Gi')
+        for label in circuit:
+            if label.is_simple():
+                expanded_circuit.append(label.name)
+            elif str(label) == '[]':
+                expanded_circuit.append('Gi')
             else:
-                raise RuntimeError(f'Cannot understand gate {gate}')
+                raise RuntimeError(f'Cannot understand label {label}')
 
     elif isinstance(circuit, str):
         # Replace [] by identity gate

--- a/silq/tools/circuit_tools.py
+++ b/silq/tools/circuit_tools.py
@@ -1,128 +1,281 @@
-from typing import Type, Union
+from typing import Union, List
 from pathlib import Path
+
 import numpy as np
-import regex as re
-pi = np.pi
+import pygsti
+from pygsti.protocols.gst import GateSetTomographyDesign
+from pygsti.protocols.rpe import RobustPhaseEstimationDesign
+from pygsti.circuits import Circuit
 
+from silq import config
+from qcodes import DataArray
 
-def convert_circuit(circuit, target_type: Type = str):
-    """Convert a circuit to a target type (e.g. list, str)
-    
+def convert_circuit(circuit, target_type: Union[str, List[str], Circuit] = str,
+                    include_state_space_labels=True,
+                    ):
+    """Convert a circuit to a target type (e.g. list, str or Circuit)
+
     Args:
         circuit: Circuit that should be converted
             Can be a str, list, or pygsti Circuit
         target_type: Target circuit type
             can be str, list, pygsti Circuit
-            
+        include_state_space_labels: If True, every gate in the circuit will be
+            represented by the operation and the target qubit (e.g. 'Gx:0'),
+            if False the target qubit is dropped.
+
     Examples:
         >>> convert_circuit('GxGi', target_type=list)
         ['Gx', 'Gi']
+        >>> convert_circuit('Gx:0Gi:1', target_type=Circuit)
+        Circuit(Gx:0Gi:1@(0,1))
+
+    Note: For all target types, the input circuit will be first converted to a
+          pygsti Circuit and then converted to the final output type. For 500
+          circuits this takes on average 5 ms. If this is found to be too slow,
+          a direct conversion may be implemented.
     """
-    from pygsti.circuits.circuit import Circuit
-    
-    # First convert all types to string
+    assert target_type in [Circuit, str, list], \
+        "Target type not understood, must be either Circuit, string or list."
+
+    # No conversion necessary
+    if isinstance(circuit, target_type):
+        return circuit
+
     if isinstance(circuit, Circuit):
-        expanded_circuit = []
-        for label in circuit:
-            if label.is_simple():
-                expanded_circuit.append(label.name)
-            elif str(label) == '[]':
-                expanded_circuit.append('Gi')
+        output_circuit = []
+        for gate in circuit:
+            if include_state_space_labels:
+                output_circuit.append(str(gate))
             else:
-                raise RuntimeError(f'Cannot understand label {label}')
+                output_circuit.append(gate.name)
 
-    elif isinstance(circuit, str):
-        # Replace [] by identity gate
-        expanded_circuit = circuit.replace('[]', 'Gi')
+        if target_type == str:
+            output_circuit = "".join(output_circuit)
 
-        # Expand any expressions ({gates})^exponent
-        expand_subcircuit = lambda match: match.group(0).replace(
-            match.group(0), match.group(1) * int(match.group(2))
-        )
-        expanded_circuit = re.sub(r'\(([A-Za-z]+)\)\^([0-9]+)', expand_subcircuit, expanded_circuit)
+    if isinstance(circuit, (str, list)):
+        # Convert to a Circuit first
+        output_circuit = Circuit(circuit)
+        output_circuit = convert_circuit(output_circuit, target_type,
+                                             include_state_space_labels)
 
-        # Expand any expressions {gate}^exponent (notice missing parentheses
-        expand_subcircuit = lambda match: match.group(0).replace(
-            match.group(0), ('G'+match.group(1)) * int(match.group(2))
-        )
-        expanded_circuit = re.sub(r'G([a-z0-9:]+)\^([0-9]+)', expand_subcircuit, expanded_circuit)
-
-        # Remove all single parentheses without exponent
-        expanded_circuit = re.sub(r"\(|\)", "", expanded_circuit)
-
-        # Newer circuits end with @(qubit idxs), which should be removed
-        expanded_circuit = expanded_circuit.split('@')[0]
-
-        if expanded_circuit == '{}':
-            expanded_circuit = ''
-
-        # Split by every letter G
-        expanded_circuit = ['G'+ gate for gate in expanded_circuit.split('G')[1:]]
-    elif isinstance(circuit, list):
-        expanded_circuit = circuit
-    else:
-        raise RuntimeError("circuit type not understood")
-
-    if target_type == str:
-        if expanded_circuit:
-            return ''.join(expanded_circuit)
-        else:
-            return '{}'
-    elif target_type == list:
-        return expanded_circuit
-    else:
-        raise NameError(f'Cannot select target type {target_type}')
+    return output_circuit
 
 
-def save_circuits(circuits, filepath):
-    """Save list of circuits to a .txt file"""
+def _get_experiment_dir(filepath: Union[str, Path],
+                        config_entry: str='properties.circuits_folder'):
+    """For relative paths, attempts to find the `filepath` in the nominated
+    circuits folder (default config.properties.circuits_folder) or in the current
+    working directory.
+
+    Search priority: absolute path, if path is relative then config circuits
+                     folder, then local directory
+
+    Args:
+        filepath: The path to a pyGSTi generated folder which includes the
+                  "edesign" and "data" subfolders
+        config_entry: The location in the silq config that specifies the default
+                    path for pyGSTi experiments.
+
+    Returns:
+        Absolute path to specified folder.
+
+    Raises:
+        FileNotFoundError
+    """
+    assert config_entry in config, f'config.{config_entry} does not exist.'
+    assert isinstance(config[config_entry], str), \
+        f"Config entry for experiment designs path must be a string and not " \
+        f"{type(config[config_entry])}"
+
     filepath = Path(filepath)
-    if not filepath.suffix:
-        filepath = filepath.with_suffix('.txt')
+    if not filepath.is_absolute():
+        config_path = Path(config[config_entry]) / filepath
+        if config_path.exists():
+            filepath = config_path
+        elif not filepath.exists():
+            raise FileNotFoundError(
+                f'Cannot find specified file "{filepath}" in'
+                f' config.{config_entry} or in '
+                f'the current directory.')
 
-    with filepath.open('w') as f:
-        for circuit in circuits:
-            circuit_str = convert_circuit(circuit, target_type=str)
-            f.write(circuit_str + '\n')
+    return filepath.absolute()
 
-
-def load_circuits(
+def load_experiment_design(
         filepath: Union[str, Path],
-        target_type: type = list,
-        load_probabilities: bool = False
+        **kwargs
 ):
-    filepath = Path(filepath)
-    with open(filepath.with_suffix('.txt')) as file:
-        lines = [line.strip() for line in file]
+    """Loads a pyGSTi experiment design from file.
 
-    # Check if line already contains data
-    if lines[0].startswith('##'):
-        # Remove header line
-        lines = lines[1:]
+    Args:
+        filepath: A relative or absolute path to a pyGSTi generated folder which
+                  includes the "edesign" and "data" subfolders.
 
-    # Remove any existing results
-    circuit_strings = [line.split(' ')[0] for line in lines]
+    Returns:
+        An experiment design.
+    """
 
-    # Ensure all strings are of the target type
-    circuits = [
-        convert_circuit(circuit, target_type=target_type)
-        for circuit in circuit_strings
-    ]
+    filepath = _get_experiment_dir(filepath, **kwargs)
 
-    if load_probabilities:
-        # Ignore when there is more than one space
-        lines = [' '.join(line.split()) for line in lines]
-        state_events = np.array([
-            [int(elem) for elem in line.split(' ')[1:]]
-            for line in lines
-        ])
-        state_probabilities = state_events / state_events.sum(axis=1)[:, None]
-        return circuits, state_probabilities
+    # If absolute file does not exist, error will be raised below.
+    return pygsti.io.read_edesign_from_dir(filepath, **kwargs)
+
+def load_GST_circuits(
+        exp_design: Union[str, GateSetTomographyDesign,
+                                  RobustPhaseEstimationDesign, Path],
+        circuit_list: str='all_circuits_needing_data',
+        **kwargs
+):
+    """Loads a pyGSTi experiment design and converts the circuits to
+        a simple format, a list of circuits which
+
+    Args:
+        exp_design: An experiment design or the path to an experiment design folder.
+
+        circuit_list: The name of the circuit list to load from the experiment design.
+
+    Returns:
+        A list of circuits, where each circuit is a list of gates represented in string format.
+    """
+    if isinstance(exp_design, (GateSetTomographyDesign, RobustPhaseEstimationDesign)):
+        pass
     else:
-        return circuits
+        exp_design = load_experiment_design(exp_design)
 
+    circuits = getattr(exp_design, circuit_list)
+
+    # Perform any necessary conversion, see defaults for convert_circuit
+    circuits = [convert_circuit(circuit, **kwargs) for circuit in circuits]
+
+    return circuits
+
+def load_dataset(path: Union[str, Path], **kwargs):
+    path = Path(path)
+    if path.suffix == '':  # Treat as path to experiment design
+        path = _get_experiment_dir(path, **kwargs) / 'data/dataset.txt'
+    elif path.suffix == 'txt' and not path.is_absolute():
+        # Relative path to .txt dataset, try config first then local directory
+        try:
+            config_path = _get_experiment_dir(path.parents[1], **kwargs) / \
+                          path.parents[0] / path.name
+
+            if config_path.exists():
+               path = config_path
+        except IndexError:
+            # Occurs if relative path does not have two parent directories.
+            pass
+
+    # Else, path is an absolute path to a .txt file, or a relative path in which
+    # case the dataset will attempt to be loaded from the current directory.
+    return pygsti.io.read_dataset(path, **kwargs)
+
+def create_dataset(results, circuits:List[Circuit], path=None):
+    """Create a pyGSTi DataSet from a results array.
+
+    Args:
+        results: A dictionary of results with keys for each measurement outcome
+                ('0', '1' for 1Q, '00', '01' etc. for 2Q and so on).
+                The value of each entry will be an array of counts.
+        circuits: An ordered list of the circuits, must be the same length as
+                the number of values in each dictionary entry.
+        path: If set, write the resulting dataset to file at the specified path.
+
+    Returns:
+        Populated pyGSTi dataset.
+    """
+
+    dataset = pygsti.data.DataSet()
+
+    # Reconstruct results dictionary to use circuits as keys
+    # Each circuit has a number of outcomes (e.g. '0' or '1') with recorded counts
+    # results = {circuit: {outcome: results[outcome][circuit_idx] for outcome in results.keys()}
+    #                for circuit_idx, circuit in enumerate(circuits)}
+
+    for k, circuit in enumerate(circuits):
+        dataset.add_count_dict(circuit, results[circuit])
+
+    if path is not None:
+        path = Path(path)
+        if path.is_dir():
+            path /= 'data/dataset.txt'
+        pygsti.io.write_dataset(path, dataset)
+
+    return dataset
 
 def analyse_circuit_results(
+    exp_design,
+    outcomes_arr:DataArray,
+    circuits:List[Circuit]=None,
+    circuits_axis=None,
+    outcomes_axis=None,
+    outcomes_mapping=None
+):
+    """
+
+    Args:
+        exp_design: A pyGSTi experiment design or path to one.
+        outcomes_arr: A QCodes DataArray which has all of the resulting counts
+                     from running the given circuits.
+        circuits: A list of pyGSTi circuits. If unspecified, the experiment design
+        'all_circuits_needing_data' is used.
+        circuits_axis: Specifies which axis distinguishes each circuit.
+        outcomes_axis: Specifies which axis distinguishes each circuit outcome.
+        outcomes_mapping: Optional, a mapping between each outcome and the index
+                    into the outcomes_arr on the outcomes_axis.
+
+    Returns:
+        A dictionary of circuit results, with the summed counts for each
+        possible outcome.
+
+    """
+    if isinstance(exp_design, (RobustPhaseEstimationDesign, GateSetTomographyDesign)):
+        pass
+    else:
+        exp_design = load_experiment_design(exp_design)
+
+    if circuits is None:
+        circuits = exp_design.all_circuits_needing_data
+
+
+
+    target_model = exp_design.create_target_model()
+    outcome_labels = list(target_model.povms['Mdefault'].keys())
+    n_outcomes = len(outcome_labels)
+
+    if outcomes_mapping is None:
+        outcomes_mapping = {label: k for k, label in enumerate(outcome_labels)}
+
+    if outcomes_axis is None:
+        # Find which axis hosts the distinct circuit outcomes
+        assert np.count_nonzero(np.array(outcomes_arr.shape) == n_outcomes) == 1,\
+        "Multiple axes were found with dimension that matches the number of " \
+        "expected outcomes. Please specify which axis distinguishes the circuit" \
+        "outcomes."
+
+        outcomes_axis = np.argmin(np.array(outcomes_arr.shape), n_outcomes)
+
+
+    if circuits_axis is None:
+        # Find which axis hosts the distinct circuit outcomes
+        assert np.count_nonzero(np.array(outcomes_arr.shape) == len(circuits)) == 1,\
+        "Multiple axes were found with dimension that matches the number of " \
+        "circuits. Please specify which axis distinguishes the circuits."
+
+        circuits_axis = np.argmin(np.array(outcomes_arr.shape), len(circuits))
+
+    # Move the circuits and outcomes axis to the final two dimensions
+    outcomes_arr = np.swapaxes(outcomes_arr, outcomes_axis, -1)
+    outcomes_arr = np.swapaxes(outcomes_arr, circuits_axis, -2)
+
+    # Assume all other dimensions are repetitions of the circuit and sum all counts
+    outcomes_arr = np.sum(outcomes_arr.reshape(-2, *outcomes_arr.shape[-2:]), axis=0)
+
+    return {circuit: {outcome_label: outcomes_arr[circuit_idx][outcomes_mapping[outcome_label]]
+                      for outcome_label in outcome_labels}
+            for circuit_idx, circuit in enumerate(circuits)}
+
+# deprecated
+def analyse_circuit_results_old(
     flips_arr,
     possible_flips_arr,
     circuits=None,
@@ -172,3 +325,49 @@ def analyse_circuit_results(
             results['filepath'] = str(output_filename)
 
     return results
+
+def save_circuits(circuits, filepath):
+    """Save list of circuits to a .txt file"""
+    filepath = Path(filepath)
+    if not filepath.suffix:
+        filepath = filepath.with_suffix('.txt')
+
+    with filepath.open('w') as f:
+        for circuit in circuits:
+            circuit_str = convert_circuit(circuit, target_type=str)
+            f.write(circuit_str + '\n')
+
+def load_circuits(
+        filepath: Union[str, Path],
+        target_type: type = list,
+        load_probabilities: bool = False
+):
+    filepath = Path(filepath)
+    with open(filepath.with_suffix('.txt')) as file:
+        lines = [line.strip() for line in file]
+
+    # Check if line already contains data
+    if lines[0].startswith('##'):
+        # Remove header line
+        lines = lines[1:]
+
+    # Remove any existing results
+    circuit_strings = [line.split(' ')[0] for line in lines]
+
+    # Ensure all strings are of the target type
+    circuits = [
+        convert_circuit(circuit, target_type=target_type)
+        for circuit in circuit_strings
+    ]
+
+    if load_probabilities:
+        # Ignore when there is more than one space
+        lines = [' '.join(line.split()) for line in lines]
+        state_events = np.array([
+            [int(elem) for elem in line.split(' ')[1:]]
+            for line in lines
+        ])
+        state_probabilities = state_events / state_events.sum(axis=1)[:, None]
+        return circuits, state_probabilities
+    else:
+        return circuits

--- a/silq/tools/general_tools.py
+++ b/silq/tools/general_tools.py
@@ -18,7 +18,7 @@ __all__ = ['execfile', 'is_between', 'get_truth', 'get_memory_usage',
            'attribute_from_config', 'clear_single_settings', 'JSONEncoder',
            'JSONListEncoder', 'run_code', 'get_exponent', 'get_first_digit',
            'ParallelTimedRotatingFileHandler', 'convert_setpoints',
-           'Singleton', 'property_ignore_setter', 'freq_to_str']
+           'Singleton', 'property_ignore_setter', 'freq_to_str', 'count_num_decimal_places']
 
 code_labels = {}
 properties_config = config['user'].get('properties', {})
@@ -658,3 +658,9 @@ def slice_length(s, l):
         return int((stop - start) / step)
     else:
         return 1
+
+
+def count_num_decimal_places(num):
+    if num > 1:
+        return 0
+    return 1 + count_num_decimal_places(10 * num)


### PR DESCRIPTION
Builds on #296, which should be merged first.

This PR adds tools to create and analyse RPE experiments that probe both the rotation angle of operations, as well as the angle between two operations (e.g. X and Y rotations).

- Adds `silq.analysis.rpe` where simple analysis and plotting tools are provided for RPE experiments.
- Adds RPE experiment generation tools to `silq.tools.circuit_tools`

N.B. I have simulated a variety of RPE experiments and there are some oddities to work out, though I believe this is to do with the simulation and not the RPE analysis.